### PR TITLE
feat: initial preview support

### DIFF
--- a/app/(personal)/layout.tsx
+++ b/app/(personal)/layout.tsx
@@ -1,5 +1,8 @@
+import { previewData } from 'next/headers'
+
 import { Footer } from '../../components/Footer'
 import { Navbar } from '../../components/Navbar'
+import { PreviewBanner } from '../../components/PreviewBanner'
 import { getSettings } from '../../lib/sanity.client'
 
 export default async function IndexRoute({
@@ -8,8 +11,12 @@ export default async function IndexRoute({
   children: React.ReactNode
 }) {
   const { menuItems, footer } = await getSettings()
+
+  const token = previewData().token
+
   return (
     <div className="flex min-h-screen flex-col bg-white text-black">
+      {token && <PreviewBanner />}
       <Navbar menuItems={menuItems} />
       <div className="mt-12 flex-grow px-32">{children}</div>
       <Footer footer={footer} />

--- a/app/(personal)/page.tsx
+++ b/app/(personal)/page.tsx
@@ -1,9 +1,27 @@
+import { previewData } from 'next/headers'
+
 import { HomePage } from '../../components/home/HomePage'
+import { HomePagePreview } from '../../components/home/HomePagePreview'
+import { PreviewSuspense } from '../../components/PreviewSuspense'
 import { getHome } from '../../lib/sanity.client'
 
 export default async function IndexRoute() {
+  const token = previewData().token || null
   const home = await getHome()
-  return <HomePage home={home} />
+
+  return (
+    <>
+      {token ? (
+        <>
+          <PreviewSuspense fallback={<HomePage home={home} />}>
+            <HomePagePreview token={token} />
+          </PreviewSuspense>
+        </>
+      ) : (
+        <HomePage home={home} />
+      )}
+    </>
+  )
 }
 
 // FIXME: remove the `revalidate` export below once you've followed the instructions in `/pages/api/revalidate.ts`

--- a/app/(personal)/page/[slug]/page.tsx
+++ b/app/(personal)/page/[slug]/page.tsx
@@ -1,9 +1,9 @@
 import { previewData } from 'next/headers'
 
-import { Page } from '../../../components/page/Page'
-import { PagePreview } from '../../../components/page/PagePreview'
-import { PreviewSuspense } from '../../../components/PreviewSuspense'
-import { getPageBySlug } from '../../../lib/sanity.client'
+import { Page } from '../../../../components/page/Page'
+import { PagePreview } from '../../../../components/page/PagePreview'
+import { PreviewSuspense } from '../../../../components/PreviewSuspense'
+import { getPageBySlug } from '../../../../lib/sanity.client'
 
 export default async function PageSlugRoute({
   params,
@@ -16,9 +16,11 @@ export default async function PageSlugRoute({
   return (
     <>
       {token ? (
-        <PreviewSuspense fallback={<Page page={about} />}>
-          <PagePreview token={token} slug={params.slug} />
-        </PreviewSuspense>
+        <>
+          <PreviewSuspense fallback={<Page page={about} />}>
+            <PagePreview token={token} slug={params.slug} />
+          </PreviewSuspense>
+        </>
       ) : (
         <Page page={about} />
       )}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,7 +11,8 @@ const serif = PT_Serif({
 const sans = Inter({
   variable: '--font-sans',
   subsets: ['latin'],
-  weight: ['500', '700', '800'],
+  // @todo: understand why extrabold (800) isn't being respected when explicitly specified in this weight array
+  // weight: ['500', '700', '800'],
 })
 const mono = IBM_Plex_Mono({
   variable: '--font-mono',

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -10,7 +10,7 @@ export function Header(props: HeaderProps) {
   const { title, description, centered = false } = props
   return (
     <div className={`${centered ? 'text-center' : 'w-3/5'}`}>
-      <div className="font-inter pb-5 text-5xl font-extrabold">{title}</div>
+      <div className="pb-5 text-5xl font-extrabold">{title}</div>
       <div className="pb-16 font-serif text-xl text-gray-600">
         <PortableText value={description} />
       </div>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -15,7 +15,7 @@ export function Navbar({ menuItems }: NavbarProps) {
           menuItems.map((menuItem, key) => (
             <Link
               key={key}
-              className={`font-inter  mr-4 hover:text-black dark:hover:text-white ${
+              className={`mr-4  hover:text-black dark:hover:text-white ${
                 menuItem?._type === 'home'
                   ? 'font-semibold text-black dark:text-white'
                   : 'text-gray-600'

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,6 +1,6 @@
-'use client'
 import Link from 'next/link'
 
+import { resolveHref } from '../lib/sanity.links'
 import { MenuItem } from '../types'
 
 interface NavbarProps {
@@ -20,7 +20,7 @@ export function Navbar({ menuItems }: NavbarProps) {
                   ? 'font-semibold text-black dark:text-white'
                   : 'text-gray-600'
               }`}
-              href={menuItem?.href}
+              href={resolveHref(menuItem?._type, menuItem?.slug)}
             >
               {menuItem.title}
             </Link>
@@ -29,5 +29,3 @@ export function Navbar({ menuItems }: NavbarProps) {
     </div>
   )
 }
-
-function resolveHref(menuItem: MenuItem) {}

--- a/components/PreviewBanner.tsx
+++ b/components/PreviewBanner.tsx
@@ -1,0 +1,15 @@
+/* eslint-disable @next/next/no-html-link-for-pages */
+interface PreviewBannerProps {
+  loading?: boolean
+}
+
+export function PreviewBanner({ loading }: PreviewBannerProps) {
+  return (
+    <div className="bg-black p-3 text-center text-white">
+      {loading ? 'Loading...' : 'This page is a preview.'}{' '}
+      <a className="underline hover:opacity-50" href="/api/exit-preview">
+        Exit preview mode
+      </a>
+    </div>
+  )
+}

--- a/components/ProjectListItem.tsx
+++ b/components/ProjectListItem.tsx
@@ -45,9 +45,7 @@ function ImageBox({ project }: { project: ShowcaseProjects }) {
 function TextBox({ project }: { project: ShowcaseProjects }) {
   return (
     <div className="relative z-0 mx-5">
-      <div className="font-inter mb-2 mt-4 text-2xl font-extrabold">
-        {project.title}
-      </div>
+      <div className="mb-2 mt-4 text-2xl font-extrabold">{project.title}</div>
       <div className="font-serif text-gray-500">
         <PortableText value={project.overview} />
       </div>

--- a/components/home/HomePagePreview.tsx
+++ b/components/home/HomePagePreview.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { usePreview } from 'lib/sanity.preview'
+
+import { homeQuery } from '../../lib/sanity.queries'
+import type { HomePagePayload } from '../../types'
+import { HomePage } from './HomePage'
+
+export function HomePagePreview({ token }: { token: null | string }) {
+  const home: HomePagePayload = usePreview(token, homeQuery)
+
+  return <HomePage home={home} />
+}

--- a/lib/sanity.links.ts
+++ b/lib/sanity.links.ts
@@ -1,0 +1,18 @@
+// @todo - consider renaming / moving elsewhere
+
+export function resolveHref(
+  documentType?: string,
+  slug?: string
+): string | undefined {
+  switch (documentType) {
+    case 'home':
+      return '/'
+    case 'page':
+      return slug ? '/page/' + slug : undefined
+    case 'project':
+      return slug ? '/project/' + slug : undefined
+    default:
+      console.warn('Invalid document type:', documentType)
+      return undefined
+  }
+}

--- a/lib/sanity.queries.ts
+++ b/lib/sanity.queries.ts
@@ -103,16 +103,8 @@ export const settingsQuery = groq`
   footer,
   menuItems[]->{
     _type,
-    (_type == 'home') => {    
-      "href": "/"
-    },
-    (_type == 'page') => {    
-      "href": slug.current      
-    },  
-    (_type == 'project') => {    
-      "href": "/project/" + slug.current      
-    },    
     content,
+    "slug": slug.current,
     title
   }
 }

--- a/pages/api/preview.ts
+++ b/pages/api/preview.ts
@@ -10,6 +10,8 @@ import type { PageConfig } from 'next/types'
 import { createClient } from 'next-sanity'
 import { getSecret } from 'plugins/productionUrl/utils'
 
+import { resolveHref } from '../../lib/sanity.links'
+
 // res.setPreviewData only exists in the nodejs runtime, setting the config here allows changing the global runtime
 // option in next.config.mjs without breaking preview mode
 export const config: PageConfig = { runtime: 'nodejs' }
@@ -68,5 +70,12 @@ export default async function preview(
     previewData.token = token
   }
 
-  return redirectToPreview(res, previewData, `/${req.query.slug}`)
+  const href = resolveHref(
+    req.query.documentType as string,
+    req.query.slug as string
+  )
+
+  console.log('href', href)
+
+  return redirectToPreview(res, previewData, href)
 }

--- a/plugins/previewPane/PreviewPane.tsx
+++ b/plugins/previewPane/PreviewPane.tsx
@@ -7,14 +7,17 @@ export type PreviewProps = ComponentProps<UserViewComponent>
  * This component is responsible for rendering a preview of a post inside the Studio.
  */
 import { getSecret } from 'plugins/productionUrl/utils'
-import React, { memo, startTransition, useEffect, useState } from 'react'
+import { memo } from 'react'
 import { useClient } from 'sanity'
 import { suspend } from 'suspend-react'
 
+import { resolveHref } from '../../lib/sanity.links'
+
 interface IframeProps {
-  slug?: string
-  previewSecretId: `${string}.${string}`
   apiVersion: string
+  documentType: string
+  previewSecretId: `${string}.${string}`
+  slug?: string
 }
 
 export function PreviewPane(
@@ -25,9 +28,12 @@ export function PreviewPane(
 ) {
   const { document, previewSecretId, apiVersion } = props
   const { displayed } = document
+  const documentType = displayed?._type
   let slug = (displayed?.slug as any)?.current
 
-  if (!slug) {
+  const href = resolveHref(documentType, displayed?.slug as string)
+
+  if (!href) {
     return (
       <Card tone="primary" margin={5} padding={6}>
         <Text align="center">
@@ -35,10 +41,6 @@ export function PreviewPane(
         </Text>
       </Card>
     )
-  }
-
-  if (displayed._type === 'project') {
-    slug = `project/${slug}`
   }
 
   return (
@@ -49,6 +51,7 @@ export function PreviewPane(
       <Suspense fallback={null}>
         <Iframe
           apiVersion={apiVersion}
+          documentType={documentType}
           previewSecretId={previewSecretId}
           slug={slug}
         />
@@ -62,7 +65,7 @@ const fetchSecret = Symbol('preview.secret')
 const Iframe = memo(function Iframe(
   props: Omit<IframeProps, 'slug'> & Required<Pick<IframeProps, 'slug'>>
 ) {
-  const { apiVersion, previewSecretId, slug } = props
+  const { apiVersion, documentType, previewSecretId, slug } = props
   const client = useClient({ apiVersion })
 
   const secret = suspend(
@@ -73,6 +76,7 @@ const Iframe = memo(function Iframe(
   )
 
   const url = new URL('/api/preview', location.origin)
+  url.searchParams.set('documentType', documentType)
   url.searchParams.set('slug', slug)
   if (secret) {
     url.searchParams.set('secret', secret)

--- a/plugins/previewPane/index.tsx
+++ b/plugins/previewPane/index.tsx
@@ -5,9 +5,8 @@
 // https://www.sanity.io/docs/structure-builder-reference
 
 import { DefaultDocumentNodeResolver } from 'sanity/desk'
-import page from 'schemas/documents/page'
-import project from 'schemas/documents/project'
 
+import { PREVIEWABLE_DOCUMENT_TYPES } from '../../sanity.config'
 import { PreviewPane } from './PreviewPane'
 
 export const previewDocumentNode = ({
@@ -18,36 +17,23 @@ export const previewDocumentNode = ({
   previewSecretId: `${string}.${string}`
 }): DefaultDocumentNodeResolver => {
   return (S, { schemaType }) => {
-    switch (schemaType) {
-      case page.name:
-        return S.document().views([
-          S.view.form(),
-          S.view
-            .component((props) => (
-              <PreviewPane
-                previewSecretId={previewSecretId}
-                apiVersion={apiVersion}
-                {...props}
-              />
-            ))
-            .title('Preview'),
-        ])
-      case project.name:
-        return S.document().views([
-          S.view.form(),
-          S.view
-            .component((props) => (
-              <PreviewPane
-                previewSecretId={previewSecretId}
-                apiVersion={apiVersion}
-                {...props}
-              />
-            ))
-            .title('Preview'),
-        ])
-
-      default:
-        return null
+    if (PREVIEWABLE_DOCUMENT_TYPES.includes(schemaType)) {
+      return S.document().views([
+        // Default form view
+        S.view.form(),
+        // Preview
+        S.view
+          .component((props) => (
+            <PreviewPane
+              previewSecretId={previewSecretId}
+              apiVersion={apiVersion}
+              {...props}
+            />
+          ))
+          .title('Preview'),
+      ])
     }
+
+    return null
   }
 }

--- a/plugins/productionUrl/index.ts
+++ b/plugins/productionUrl/index.ts
@@ -42,7 +42,7 @@ export const productionUrl = definePlugin<{
         }
 
         if (types.has(document._type)) {
-          url.searchParams.set('type', document._type)
+          url.searchParams.set('documentType', document._type)
           console.log('Open preview URL', url.toString())
           return url.toString()
         }

--- a/plugins/settings.tsx
+++ b/plugins/settings.tsx
@@ -5,6 +5,10 @@
 import { type DocumentDefinition } from 'sanity'
 import { type StructureResolver } from 'sanity/desk'
 
+import { apiVersion, previewSecretId } from '../lib/sanity.api'
+import { PREVIEWABLE_DOCUMENT_TYPES } from '../sanity.config'
+import { PreviewPane } from './previewPane/PreviewPane'
+
 export const singletonPlugin = (types: string[]) => {
   return {
     name: 'singletonPlugin',
@@ -49,6 +53,25 @@ export const pageStructure = (
             .id(typeDef.name)
             .schemaType(typeDef.name)
             .documentId(typeDef.name)
+            .views([
+              // @todo: consider DRYing with `plugins/previewPane/index.tsx`
+              // Default form view
+              S.view.form(),
+              // Preview
+              ...(PREVIEWABLE_DOCUMENT_TYPES.includes(typeDef.name)
+                ? [
+                    S.view
+                      .component((props) => (
+                        <PreviewPane
+                          previewSecretId={previewSecretId}
+                          apiVersion={apiVersion}
+                          {...props}
+                        />
+                      ))
+                      .title('Preview'),
+                  ]
+                : []),
+            ])
         )
     })
 

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -11,8 +11,8 @@ import { defineConfig } from 'sanity'
 import { deskTool } from 'sanity/desk'
 import { unsplashImageAsset } from 'sanity-plugin-asset-source-unsplash'
 import page from 'schemas/documents/page'
-import projectType from 'schemas/documents/project'
-import durationType from 'schemas/objects/duration'
+import project from 'schemas/documents/project'
+import duration from 'schemas/objects/duration'
 import timeline from 'schemas/objects/timeline'
 import home from 'schemas/singletons/home'
 import settings from 'schemas/singletons/settings'
@@ -20,6 +20,12 @@ import settings from 'schemas/singletons/settings'
 const title =
   process.env.NEXT_PUBLIC_SANITY_PROJECT_TITLE ||
   'Next.js Personal Website with Sanity.io'
+
+export const PREVIEWABLE_DOCUMENT_TYPES: string[] = [
+  home.name,
+  page.name,
+  project.name,
+]
 
 export default defineConfig({
   basePath: '/studio',
@@ -33,9 +39,9 @@ export default defineConfig({
       home,
       settings,
       // Documents
-      durationType,
+      duration,
       page,
-      projectType,
+      project,
       // Objects
       timeline,
     ],
@@ -52,7 +58,7 @@ export default defineConfig({
     productionUrl({
       apiVersion,
       previewSecretId,
-      types: [home.name],
+      types: PREVIEWABLE_DOCUMENT_TYPES,
     }),
     // Add an image asset source for Unsplash
     unsplashImageAsset(),

--- a/types/index.ts
+++ b/types/index.ts
@@ -8,6 +8,7 @@ export interface MenuItem {
   content?: any[]
   href?: string
   overview?: any[]
+  slug?: string
   title?: string
 }
 


### PR DESCRIPTION
- (Next) Add preview banner (stored in app layout, rather than on the page level)
- (Studio) Preview panes for projects, pages and the home page
- (Studio) Open preview button support
- (Next) Moved pages back into `/page/`
  - @RitaDias agree this isn't super aesthetically pleasing, but it does mean we don't need to worry about handling 404s (e.g. with `[slug]`, we'll need to handle cases where users visit `/this-does-not-totally-exist`)
- (Next) created a simple `resolveHref` util which generates those full paths for us, which is re-used in various contexts
- (Next) quick workaround to get tailwind styles working (for some reason, extrabold just isn't working for me when manually specifying font weights with Inter)