### PR TITLE
Fix IntroTemplate remove links

### DIFF
--- a/intro-template/index.tsx
+++ b/intro-template/index.tsx
@@ -19,8 +19,8 @@ export default memo(function IntroTemplate() {
     process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_SLUG
   const repoURL = `https://${process.env.NEXT_PUBLIC_VERCEL_GIT_PROVIDER}.com/${process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_OWNER}/${process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_SLUG}`
   const removeBlockURL = hasRepoEnvVars
-    ? `https://${process.env.NEXT_PUBLIC_VERCEL_GIT_PROVIDER}.com/${process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_OWNER}/${process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_SLUG}/blob/main/README.md#how-can-i-remove-the-next-steps-block-from-my-app`
-    : `https://github.com/sanity-io/template-nextjs-clean#how-can-i-remove-the-next-steps-block-from-my-app`
+    ? `https://${process.env.NEXT_PUBLIC_VERCEL_GIT_PROVIDER}.com/${process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_OWNER}/${process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_SLUG}/blob/main/README.md#user-content-how-can-i-remove-the-next-steps-block-from-my-personal-website`
+    : `https://github.com/sanity-io/template-nextjs-personal-website#user-content-how-can-i-remove-the-next-steps-block-from-my-personal-website`
 
   const [hasUTMtags, setHasUTMtags] = useState(false)
 


### PR DESCRIPTION
The links were broken because the project folder and the README have been modified.

I've updated the links from:
https://github.com/sanity-io/template-nextjs-clean#how-can-i-remove-the-next-steps-block-from-my-app

To:
https://github.com/sanity-io/template-nextjs-personal-website#user-content-how-can-i-remove-the-next-steps-block-from-my-personal-website