### PR TITLE
fix: unlock incremental static regeneration

### DIFF
--- a/sanity/loader/generateStaticSlugs.ts
+++ b/sanity/loader/generateStaticSlugs.ts
@@ -18,5 +18,11 @@ export function generateStaticSlugs(type: string) {
     .fetch<string[]>(
       groq`*[_type == $type && defined(slug.current)]{"slug": slug.current}`,
       { type },
+      {
+        next: {
+          tags: [type]
+        }
+      }
     )
+
 }


### PR DESCRIPTION
The statically generated pages for routes [slug] and project/[slug] will not update on revalidateTag, because we aren't using any tags in the code path for generateStaticParams in those routes.

This should fix https://github.com/sanity-io/template-nextjs-personal-website/issues/112