### PR TITLE
fix: exception thrown when adding a project

### DIFF
--- a/components/pages/home/HomePage.tsx
+++ b/components/pages/home/HomePage.tsx
@@ -23,7 +23,7 @@ export function HomePage({ data, encodeDataAttribute }: HomePageProps) {
       {showcaseProjects && showcaseProjects.length > 0 && (
         <div className="mx-auto max-w-[100rem] rounded-md border">
           {showcaseProjects.map((project, key) => {
-            const href = resolveHref(project._type, project.slug)
+            const href = resolveHref(project?._type, project?.slug)
             if (!href) {
               return null
             }


### PR DESCRIPTION
@simonhrogers following up on https://github.com/sanity-io/next-sanity/issues/639#issuecomment-1899047479, it turns out that in our case we just didn't have `/api/revalidate` in our GROQ webhook config, and revalidateTag started working in our test deploy just fine after correcting it.

If you've been changing what `tags` you've been giving your queries, make sure that you perform a purge afterwards in order for `revalidateTag` to "find" all the queries that are affected. If you don't you'll have cached queries that may have incorrect `tags`, or no tags, and they'll have no way of being purged as you call `revalidateTag`:

![image](https://github.com/sanity-io/template-nextjs-personal-website/assets/81981/1e162ede-3877-4012-86eb-e5796f8e0f4a)
