### PR TITLE
fix: remove @sanity/presentation direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
         "@sanity/demo": "2.0.0",
         "@sanity/icons": "2.11.8",
         "@sanity/image-url": "1.0.2",
-        "@sanity/presentation": "1.15.2",
         "@sanity/preview-url-secret": "1.6.12",
         "@sanity/react-loader": "1.9.18",
         "@sanity/ui": "2.1.7",
@@ -23,7 +22,7 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "rxjs": "7.8.1",
-        "sanity": "3.41.1",
+        "sanity": "3.40.0",
         "sanity-plugin-asset-source-unsplash": "3.0.1",
         "server-only": "0.0.1",
         "styled-components": "6.1.11"
@@ -2178,9 +2177,9 @@
       "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.2.tgz",
-      "integrity": "sha512-/c7hocx0pm14bHQlqUVKmxwdT/e5/KkyoY1W8F9lk/8CkE037STDDz8PXUP/LE6faj2HqchvDs9GcShxFhI78Q==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
       "cpu": [
         "ppc64"
       ],
@@ -2193,9 +2192,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.2.tgz",
-      "integrity": "sha512-G1ve3b4FeyJeyCjB4MX1CiWyTaIJwT9wAYE+8+IRA53YoN/reC/Bf2GDRXAzDTnh69Fpl+1uIKg76DiB3U6vwQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
       "cpu": [
         "arm"
       ],
@@ -2208,9 +2207,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.2.tgz",
-      "integrity": "sha512-SGZKngoTWVUriO5bDjI4WDGsNx2VKZoXcds+ita/kVYB+8IkSCKDRDaK+5yu0b5S0eq6B3S7fpiEvpsa2ammlQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
       "cpu": [
         "arm64"
       ],
@@ -2223,9 +2222,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.2.tgz",
-      "integrity": "sha512-1wzzNoj2QtNkAYwIcWJ66UTRA80+RTQ/kuPMtEuP0X6dp5Ar23Dn566q3aV61h4EYrrgGlOgl/HdcqN/2S/2vg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
       "cpu": [
         "x64"
       ],
@@ -2238,9 +2237,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.2.tgz",
-      "integrity": "sha512-ZyMkPWc5eTROcLOA10lEqdDSTc6ds6nuh3DeHgKip/XJrYjZDfnkCVSty8svWdy+SC1f77ULtVeIqymTzaB6/Q==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
       "cpu": [
         "arm64"
       ],
@@ -2253,9 +2252,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.2.tgz",
-      "integrity": "sha512-K4ZdVq1zP9v51h/cKVna7im7G0zGTKKB6bP2yJiSmHjjOykbd8DdhrSi8V978sF69rkwrn8zCyL2t6I3ei6j9A==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
       "cpu": [
         "x64"
       ],
@@ -2268,9 +2267,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.2.tgz",
-      "integrity": "sha512-4kbOGdpA61CXqadD+Gb/Pw3YXamQGiz9mal/h93rFVSjr5cgMnmJd/gbfPRm+3BMifvnaOfS1gNWaIDxkE2A3A==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
       "cpu": [
         "arm64"
       ],
@@ -2283,9 +2282,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.2.tgz",
-      "integrity": "sha512-ShS+R09nuHzDBfPeMUliKZX27Wrmr8UFp93aFf/S8p+++x5BZ+D344CLKXxmY6qzgTL3mILSImPCNJOzD6+RRg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
       "cpu": [
         "x64"
       ],
@@ -2298,9 +2297,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.2.tgz",
-      "integrity": "sha512-nnGXjOAv+7cM3LYRx4tJsYdgy8dGDGkAzF06oIDGppWbUkUKN9SmgQA8H0KukpU0Pjrj9XmgbWqMVSX/U7eeTA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
       "cpu": [
         "arm"
       ],
@@ -2313,9 +2312,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.2.tgz",
-      "integrity": "sha512-Hdu8BL+AmO+eCDvvT6kz/fPQhvuHL8YK4ExKZfANWsNe1kFGOHw7VJvS/FKSLFqheXmB3rTF3xFQIgUWPYsGnA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
       "cpu": [
         "arm64"
       ],
@@ -2328,9 +2327,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.2.tgz",
-      "integrity": "sha512-m73BOCW2V9lcj7RtEMi+gBfHC6n3+VHpwQXP5offtQMPLDkpVolYn1YGXxOZ9hp4h3UPRKuezL7WkBsw+3EB3Q==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
       "cpu": [
         "ia32"
       ],
@@ -2343,9 +2342,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.2.tgz",
-      "integrity": "sha512-84eYHwwWHq3myIY/6ikALMcnwkf6Qo7NIq++xH0x+cJuUNpdwh8mlpUtRY+JiGUc60yu7ElWBbVHGWTABTclGw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
       "cpu": [
         "loong64"
       ],
@@ -2358,9 +2357,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.2.tgz",
-      "integrity": "sha512-9siSZngT0/ZKG+AH+/agwKF29LdCxw4ODi/PiE0F52B2rtLozlDP92umf8G2GPoVV611LN4pZ+nSTckebOscUA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
       "cpu": [
         "mips64el"
       ],
@@ -2373,9 +2372,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.2.tgz",
-      "integrity": "sha512-y0T4aV2CA+ic04ULya1A/8M2RDpDSK2ckgTj6jzHKFJvCq0jQg8afQQIn4EM0G8u2neyOiNHgSF9YKPfuqKOVw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
       "cpu": [
         "ppc64"
       ],
@@ -2388,9 +2387,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.2.tgz",
-      "integrity": "sha512-x5ssCdXmZC86L2Li1qQPF/VaC4VP20u/Zm8jlAu9IiVOVi79YsSz6cpPDYZl1rfKSHYCJW9XBfFCo66S5gVPSA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
       "cpu": [
         "riscv64"
       ],
@@ -2403,9 +2402,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.2.tgz",
-      "integrity": "sha512-NP7fTpGSFWdXyvp8iAFU04uFh9ARoplFVM/m+8lTRpaYG+2ytHPZWyscSsMM6cvObSIK2KoPHXiZD4l99WaxbQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
       "cpu": [
         "s390x"
       ],
@@ -2418,9 +2417,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.2.tgz",
-      "integrity": "sha512-giZ/uOxWDKda44ZuyfKbykeXznfuVNkTgXOUOPJIjbayJV6FRpQ4zxUy9JMBPLaK9IJcdWtaoeQrYBMh3Rr4vQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
       "cpu": [
         "x64"
       ],
@@ -2433,9 +2432,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.2.tgz",
-      "integrity": "sha512-IeFMfGFSQfIj1d4XU+6lkbFzMR+mFELUUVYrZ+jvWzG4NGvs6o53ReEHLHpYkjRbdEjJy2W3lTekTxrFHW7YJg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
       "cpu": [
         "x64"
       ],
@@ -2448,9 +2447,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.2.tgz",
-      "integrity": "sha512-48QhWD6WxcebNNaE4FCwgvQVUnAycuTd+BdvA/oZu+/MmbpU8pY2dMEYlYzj5uNHWIG5jvdDmFXu0naQeOWUoA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
       "cpu": [
         "x64"
       ],
@@ -2463,9 +2462,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.2.tgz",
-      "integrity": "sha512-90r3nTBLgdIgD4FCVV9+cR6Hq2Dzs319icVsln+NTmTVwffWcCqXGml8rAoocHuJ85kZK36DCteii96ba/PX8g==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
       "cpu": [
         "x64"
       ],
@@ -2478,9 +2477,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.2.tgz",
-      "integrity": "sha512-sNndlsBT8OeE/MZDSGpRDJlWuhjuUz/dn80nH0EP4ZzDUYvMDVa7G87DVpweBrn4xdJYyXS/y4CQNrf7R2ODXg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
       "cpu": [
         "arm64"
       ],
@@ -2493,9 +2492,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.2.tgz",
-      "integrity": "sha512-Ti2QChGNFzWhUNNVuU4w21YkYTErsNh3h+CzvlEhzgRbwsJ7TrWQqRzW3bllLKKvTppuF3DJ3XP1GEg11AfrEQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
       "cpu": [
         "ia32"
       ],
@@ -2508,9 +2507,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.2.tgz",
-      "integrity": "sha512-VEfTCZicoZnZ6sGkjFPGRFFJuL2fZn2bLhsekZl1CJslflp2cJS/VoKs1jMk+3pDfsGW6CfQVUckP707HwbXeQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
       "cpu": [
         "x64"
       ],
@@ -3052,30 +3051,30 @@
       }
     },
     "node_modules/@sanity/block-tools": {
-      "version": "3.41.1",
-      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.41.1.tgz",
-      "integrity": "sha512-ffYiwFx0J3QmRIPZi6U86/8ihyIyKbF9/1+ceOfX6HdMukVZijrBJcG6H5+I0ZErgbQZBWPj+OaCVC3PL4H3VA==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.40.0.tgz",
+      "integrity": "sha512-6j7CYHmNFVgiabpbigFk5BwbqTh/Y3FFH8phAXUuB9htk30GQkYxZ988Sd8+WROcTou5d5ZkcY+CrkdxgH3R8w==",
       "dependencies": {
         "get-random-values-esm": "1.0.2",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@sanity/cli": {
-      "version": "3.41.1",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.41.1.tgz",
-      "integrity": "sha512-7pWog0nslyR2CMZMTpo3vS+09z2eJuteSJBm11t3WvxSYZBFA6iJvpNFXBQZJctiZZlnNoVXedI6R1NuqoTnDA==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.40.0.tgz",
+      "integrity": "sha512-6VDHmwbhXHQGsyc7YKV0WkgSvTaQlFeT3G/RAdxA/cmtuHcKOpTtQCIzsearzs6NDQ+AgniutEHCTcWHqS28jQ==",
       "dependencies": {
         "@babel/traverse": "^7.23.5",
-        "@sanity/client": "^6.17.2",
-        "@sanity/codegen": "3.41.1",
+        "@sanity/client": "^6.15.20",
+        "@sanity/codegen": "3.40.0",
         "@sanity/telemetry": "^0.7.6",
-        "@sanity/util": "3.41.1",
+        "@sanity/util": "3.40.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.4",
         "decompress": "^4.2.0",
-        "esbuild": "^0.21.0",
+        "esbuild": "^0.20.0",
         "esbuild-register": "^3.4.1",
-        "get-it": "^8.4.28",
+        "get-it": "^8.4.27",
         "groq-js": "^1.8.0",
         "node-machine-id": "^1.1.12",
         "pkg-dir": "^5.0.0",
@@ -3092,21 +3091,21 @@
       }
     },
     "node_modules/@sanity/cli/node_modules/@sanity/types": {
-      "version": "3.41.1",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.41.1.tgz",
-      "integrity": "sha512-29pRfXQ6a89ozbZFQaUI/ldHde4bl/DL634CBj0gxTMYuFY7x/wLgCsjjDnMcJsB9Eiq+8enV8LNKdChGhW0Hg==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.40.0.tgz",
+      "integrity": "sha512-DS2QhzLFtb8Xc5Ur3pV5lE8Tk9CGwDmjOJUDMPDtgH9ESgiZgaC2TVsUHNX4e0s1kN2jzxH7q4gfFKFxKrX9yw==",
       "dependencies": {
-        "@sanity/client": "^6.17.2",
+        "@sanity/client": "^6.15.20",
         "@types/react": "^18.0.25"
       }
     },
     "node_modules/@sanity/cli/node_modules/@sanity/util": {
-      "version": "3.41.1",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.41.1.tgz",
-      "integrity": "sha512-rMOKJqXiJwLvGXx91SiAiBwV1pm4MelAfLOuld3wDWc4XANKSicfX2jcfLhgU3WprOM4aaOEumiA1JEnqdanaQ==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.40.0.tgz",
+      "integrity": "sha512-FfNxUfDfY2czVQnEDwDNMGaPgsxwZyh71De7KMQYs3GyZmPxlOdPipXkB18vlie2VycXnvm/i1gCSU3XxyxUAQ==",
       "dependencies": {
-        "@sanity/client": "^6.17.2",
-        "@sanity/types": "3.41.1",
+        "@sanity/client": "^6.15.20",
+        "@sanity/types": "3.40.0",
         "get-random-values-esm": "1.0.2",
         "moment": "^2.29.4",
         "rxjs": "^7.8.1"
@@ -3129,9 +3128,9 @@
       }
     },
     "node_modules/@sanity/codegen": {
-      "version": "3.41.1",
-      "resolved": "https://registry.npmjs.org/@sanity/codegen/-/codegen-3.41.1.tgz",
-      "integrity": "sha512-g9ZWJ1EwFh72CzuMtajBgZ9aN4wKiyzoqJF5d/ewnflBELPKKVzsh35Q3XqW5KtuLRIjNknyokOU5+NaAvH0mg==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@sanity/codegen/-/codegen-3.40.0.tgz",
+      "integrity": "sha512-qC9mLDPiWx5UbUnF8VmoUpddQOIHKO+7ICAndGRzyFAHgnOUC0mrcVFIfhctnJjZIp+5pOB4QKatCz5xpQWLrw==",
       "dependencies": {
         "@babel/core": "^7.23.9",
         "@babel/generator": "^7.23.6",
@@ -3143,7 +3142,7 @@
         "@babel/types": "^7.23.9",
         "debug": "^4.3.4",
         "globby": "^10.0.0",
-        "groq": "3.41.1",
+        "groq": "3.40.0",
         "groq-js": "^1.8.0",
         "json5": "^2.2.3",
         "tsconfig-paths": "^4.2.0",
@@ -3190,6 +3189,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/@sanity/codegen/node_modules/groq": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/groq/-/groq-3.40.0.tgz",
+      "integrity": "sha512-Ru5/d9f1UIQLkkw4w/kpjtKOtw63b2fv5Prg8JEGCB8af6H5UXY8VWcm/1sPYCmxnJdalfhQ5ZhQzRMgk+O2wQ==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@sanity/codegen/node_modules/tsconfig-paths": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
@@ -3232,9 +3239,9 @@
       }
     },
     "node_modules/@sanity/diff": {
-      "version": "3.41.1",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.41.1.tgz",
-      "integrity": "sha512-BTS7S+MIHSbfXi9v0eCo6DoY2hPUXzUbwZKh9iFUaCJm9CXnHKS0VErnAGvQBWrHSINC72ZEW09RXxBgfao2nA==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.40.0.tgz",
+      "integrity": "sha512-SkrEZ//JQ8ZmXONuj7eVr7qIRc09+P0tg0JnWcRIPtWiGUl7CqPST4hcTivOpg1HKNVvUkHZNGeWKMjFDmCmSg==",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.1.1"
       },
@@ -3457,14 +3464,14 @@
       }
     },
     "node_modules/@sanity/migrate": {
-      "version": "3.41.1",
-      "resolved": "https://registry.npmjs.org/@sanity/migrate/-/migrate-3.41.1.tgz",
-      "integrity": "sha512-Kq2cZQ3i/mWMrJP+7IXvGafCiLHXSPZh5lY82OscuvTdYol+gYHgU/ILA6PPAdfGk2dgI0yDWdK6XzV99cQplg==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@sanity/migrate/-/migrate-3.40.0.tgz",
+      "integrity": "sha512-lnluF/WRa05AiGrb/OpGOaXisaqZ0VxnLYbJco7PNFDmfq2FUZ4h5TcCqpXIT2T4jq5Lt5ra7mGhsf6LhIQtLw==",
       "dependencies": {
         "@bjoerge/mutiny": "^0.5.1",
-        "@sanity/client": "^6.17.2",
-        "@sanity/types": "3.41.1",
-        "@sanity/util": "3.41.1",
+        "@sanity/client": "^6.15.20",
+        "@sanity/types": "3.40.0",
+        "@sanity/util": "3.40.0",
         "arrify": "^2.0.1",
         "debug": "^4.3.4",
         "fast-fifo": "^1.3.2",
@@ -3476,21 +3483,21 @@
       }
     },
     "node_modules/@sanity/migrate/node_modules/@sanity/types": {
-      "version": "3.41.1",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.41.1.tgz",
-      "integrity": "sha512-29pRfXQ6a89ozbZFQaUI/ldHde4bl/DL634CBj0gxTMYuFY7x/wLgCsjjDnMcJsB9Eiq+8enV8LNKdChGhW0Hg==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.40.0.tgz",
+      "integrity": "sha512-DS2QhzLFtb8Xc5Ur3pV5lE8Tk9CGwDmjOJUDMPDtgH9ESgiZgaC2TVsUHNX4e0s1kN2jzxH7q4gfFKFxKrX9yw==",
       "dependencies": {
-        "@sanity/client": "^6.17.2",
+        "@sanity/client": "^6.15.20",
         "@types/react": "^18.0.25"
       }
     },
     "node_modules/@sanity/migrate/node_modules/@sanity/util": {
-      "version": "3.41.1",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.41.1.tgz",
-      "integrity": "sha512-rMOKJqXiJwLvGXx91SiAiBwV1pm4MelAfLOuld3wDWc4XANKSicfX2jcfLhgU3WprOM4aaOEumiA1JEnqdanaQ==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.40.0.tgz",
+      "integrity": "sha512-FfNxUfDfY2czVQnEDwDNMGaPgsxwZyh71De7KMQYs3GyZmPxlOdPipXkB18vlie2VycXnvm/i1gCSU3XxyxUAQ==",
       "dependencies": {
-        "@sanity/client": "^6.17.2",
-        "@sanity/types": "3.41.1",
+        "@sanity/client": "^6.15.20",
+        "@sanity/types": "3.40.0",
         "get-random-values-esm": "1.0.2",
         "moment": "^2.29.4",
         "rxjs": "^7.8.1"
@@ -3508,9 +3515,9 @@
       }
     },
     "node_modules/@sanity/mutator": {
-      "version": "3.41.1",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.41.1.tgz",
-      "integrity": "sha512-MDRDf1zFwypllzdC0DdHm1RnBbjq7SAfSSI8utvq04PTpuCZcqSZPVq13fGqZx4JTsUDvjDuBKq7LO/bbxdQOw==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.40.0.tgz",
+      "integrity": "sha512-IoZSHpBpieTwOEfU94SLP8OIpMs7453Rk0O94/roER6RJQ831ixoR6qH9T8/pS4dg/I3CJfEgiBRodXWJS72lA==",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.1.1",
         "@sanity/uuid": "^3.0.1",
@@ -3519,14 +3526,14 @@
       }
     },
     "node_modules/@sanity/portable-text-editor": {
-      "version": "3.41.1",
-      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.41.1.tgz",
-      "integrity": "sha512-QCc6MwqcR+r5PvjeroNy/1aMdvIxX6+7jBLutaCj8G/gHUZjdEggspWuRmNfvbhdGyJYwp6gAi27zFdOZN+X2w==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.40.0.tgz",
+      "integrity": "sha512-cR8LvpHHTpmpgCcmV8HmLe2l7vaOEEsYV1WYvOfIQmKMyPvVWlPT1Nbp82C6OtprLCvd4cpzhbu4rUxkos8IHQ==",
       "dependencies": {
-        "@sanity/block-tools": "3.41.1",
-        "@sanity/schema": "3.41.1",
-        "@sanity/types": "3.41.1",
-        "@sanity/util": "3.41.1",
+        "@sanity/block-tools": "3.40.0",
+        "@sanity/schema": "3.40.0",
+        "@sanity/types": "3.40.0",
+        "@sanity/util": "3.40.0",
         "debug": "^3.2.7",
         "is-hotkey-esm": "^1.0.0",
         "lodash": "^4.17.21",
@@ -3543,21 +3550,21 @@
       }
     },
     "node_modules/@sanity/portable-text-editor/node_modules/@sanity/types": {
-      "version": "3.41.1",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.41.1.tgz",
-      "integrity": "sha512-29pRfXQ6a89ozbZFQaUI/ldHde4bl/DL634CBj0gxTMYuFY7x/wLgCsjjDnMcJsB9Eiq+8enV8LNKdChGhW0Hg==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.40.0.tgz",
+      "integrity": "sha512-DS2QhzLFtb8Xc5Ur3pV5lE8Tk9CGwDmjOJUDMPDtgH9ESgiZgaC2TVsUHNX4e0s1kN2jzxH7q4gfFKFxKrX9yw==",
       "dependencies": {
-        "@sanity/client": "^6.17.2",
+        "@sanity/client": "^6.15.20",
         "@types/react": "^18.0.25"
       }
     },
     "node_modules/@sanity/portable-text-editor/node_modules/@sanity/util": {
-      "version": "3.41.1",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.41.1.tgz",
-      "integrity": "sha512-rMOKJqXiJwLvGXx91SiAiBwV1pm4MelAfLOuld3wDWc4XANKSicfX2jcfLhgU3WprOM4aaOEumiA1JEnqdanaQ==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.40.0.tgz",
+      "integrity": "sha512-FfNxUfDfY2czVQnEDwDNMGaPgsxwZyh71De7KMQYs3GyZmPxlOdPipXkB18vlie2VycXnvm/i1gCSU3XxyxUAQ==",
       "dependencies": {
-        "@sanity/client": "^6.17.2",
-        "@sanity/types": "3.41.1",
+        "@sanity/client": "^6.15.20",
+        "@sanity/types": "3.40.0",
         "get-random-values-esm": "1.0.2",
         "moment": "^2.29.4",
         "rxjs": "^7.8.1"
@@ -3572,32 +3579,6 @@
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dependencies": {
         "ms": "^2.1.1"
-      }
-    },
-    "node_modules/@sanity/presentation": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@sanity/presentation/-/presentation-1.15.2.tgz",
-      "integrity": "sha512-2fOvi1wt9Zlrc4F/ZKWonHkRIIuHT5OKAZmEaZgyTcaJ11HVasn1ddkT/4aomyjHjTy7D70S9A74G0QPpHSGVw==",
-      "dependencies": {
-        "@sanity/icons": "^2.11.8",
-        "@sanity/preview-url-secret": "^1.6.12",
-        "@sanity/ui": "^2.1.7",
-        "@sanity/uuid": "3.0.2",
-        "@types/lodash.isequal": "^4.5.8",
-        "fast-deep-equal": "3.1.3",
-        "framer-motion": "11.0.8",
-        "lodash.isequal": "^4.5.0",
-        "mendoza": "3.0.7",
-        "mnemonist": "0.39.8",
-        "path-to-regexp": "^6.2.2",
-        "rxjs": "^7.8.1",
-        "suspend-react": "0.1.3"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "@sanity/client": "^6.18.0"
       }
     },
     "node_modules/@sanity/preview-kit": {
@@ -3663,12 +3644,12 @@
       }
     },
     "node_modules/@sanity/schema": {
-      "version": "3.41.1",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.41.1.tgz",
-      "integrity": "sha512-ZWZF9mujt0+JFFHlGIp0mVgA55JXe84YjYHJEH0SGOfYCWY77vzePkUtEIwODW19RhzR5JmAAl851GTXWFcoMQ==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.40.0.tgz",
+      "integrity": "sha512-OMNpBkDKqxXCMZwOMsjkgvDHrFhJiT6nyLl8u1wqlXpD6tp0wK7Ljl/ALva2L1BUAaICmlSqZvfWuaOko2psnw==",
       "dependencies": {
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/types": "3.41.1",
+        "@sanity/types": "3.40.0",
         "arrify": "^1.0.1",
         "groq-js": "^1.8.0",
         "humanize-list": "^1.0.1",
@@ -3678,11 +3659,11 @@
       }
     },
     "node_modules/@sanity/schema/node_modules/@sanity/types": {
-      "version": "3.41.1",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.41.1.tgz",
-      "integrity": "sha512-29pRfXQ6a89ozbZFQaUI/ldHde4bl/DL634CBj0gxTMYuFY7x/wLgCsjjDnMcJsB9Eiq+8enV8LNKdChGhW0Hg==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.40.0.tgz",
+      "integrity": "sha512-DS2QhzLFtb8Xc5Ur3pV5lE8Tk9CGwDmjOJUDMPDtgH9ESgiZgaC2TVsUHNX4e0s1kN2jzxH7q4gfFKFxKrX9yw==",
       "dependencies": {
-        "@sanity/client": "^6.17.2",
+        "@sanity/client": "^6.15.20",
         "@types/react": "^18.0.25"
       }
     },
@@ -4234,6 +4215,11 @@
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0"
       }
+    },
+    "node_modules/@vvo/tzdb": {
+      "version": "6.138.0",
+      "resolved": "https://registry.npmjs.org/@vvo/tzdb/-/tzdb-6.138.0.tgz",
+      "integrity": "sha512-s7lB3N1MwywA+0f75aUCTmpIBsWK0CmR7Tu5/6qGh3ta/GAQkmVACkmhyf3HuM2oExIS97qvRFdfVdvpF/vR+g=="
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -5540,9 +5526,9 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.0.tgz",
-      "integrity": "sha512-vYq4L+T8aS5UuFg4UwDhc7YNRWVeVZwltad9C/jV3R2LgVOpS9BDr7l/WL6BN0dbV3k1XejPTHqqEzJgsa0frA==",
+      "version": "3.37.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.1.tgz",
+      "integrity": "sha512-9TNiImhKvQqSUkOvk/mMRZzOANTiEVC7WaBNhHcKM7x+/5E1l5NvsysR19zuDQScE8k+kfQXWRN3AtS/eOSHpg==",
       "dependencies": {
         "browserslist": "^4.23.0"
       },
@@ -6463,9 +6449,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.2.tgz",
-      "integrity": "sha512-LmHPAa5h4tSxz+g/D8IHY6wCjtIiFx8I7/Q0Aq+NmvtoYvyMnJU0KQJcqB6QH30X9x/W4CemgUtPgQDZFca5SA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -6474,29 +6460,29 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.2",
-        "@esbuild/android-arm": "0.21.2",
-        "@esbuild/android-arm64": "0.21.2",
-        "@esbuild/android-x64": "0.21.2",
-        "@esbuild/darwin-arm64": "0.21.2",
-        "@esbuild/darwin-x64": "0.21.2",
-        "@esbuild/freebsd-arm64": "0.21.2",
-        "@esbuild/freebsd-x64": "0.21.2",
-        "@esbuild/linux-arm": "0.21.2",
-        "@esbuild/linux-arm64": "0.21.2",
-        "@esbuild/linux-ia32": "0.21.2",
-        "@esbuild/linux-loong64": "0.21.2",
-        "@esbuild/linux-mips64el": "0.21.2",
-        "@esbuild/linux-ppc64": "0.21.2",
-        "@esbuild/linux-riscv64": "0.21.2",
-        "@esbuild/linux-s390x": "0.21.2",
-        "@esbuild/linux-x64": "0.21.2",
-        "@esbuild/netbsd-x64": "0.21.2",
-        "@esbuild/openbsd-x64": "0.21.2",
-        "@esbuild/sunos-x64": "0.21.2",
-        "@esbuild/win32-arm64": "0.21.2",
-        "@esbuild/win32-ia32": "0.21.2",
-        "@esbuild/win32-x64": "0.21.2"
+        "@esbuild/aix-ppc64": "0.20.2",
+        "@esbuild/android-arm": "0.20.2",
+        "@esbuild/android-arm64": "0.20.2",
+        "@esbuild/android-x64": "0.20.2",
+        "@esbuild/darwin-arm64": "0.20.2",
+        "@esbuild/darwin-x64": "0.20.2",
+        "@esbuild/freebsd-arm64": "0.20.2",
+        "@esbuild/freebsd-x64": "0.20.2",
+        "@esbuild/linux-arm": "0.20.2",
+        "@esbuild/linux-arm64": "0.20.2",
+        "@esbuild/linux-ia32": "0.20.2",
+        "@esbuild/linux-loong64": "0.20.2",
+        "@esbuild/linux-mips64el": "0.20.2",
+        "@esbuild/linux-ppc64": "0.20.2",
+        "@esbuild/linux-riscv64": "0.20.2",
+        "@esbuild/linux-s390x": "0.20.2",
+        "@esbuild/linux-x64": "0.20.2",
+        "@esbuild/netbsd-x64": "0.20.2",
+        "@esbuild/openbsd-x64": "0.20.2",
+        "@esbuild/sunos-x64": "0.20.2",
+        "@esbuild/win32-arm64": "0.20.2",
+        "@esbuild/win32-ia32": "0.20.2",
+        "@esbuild/win32-x64": "0.20.2"
       }
     },
     "node_modules/esbuild-register": {
@@ -7782,9 +7768,9 @@
       }
     },
     "node_modules/groq-js": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-1.8.0.tgz",
-      "integrity": "sha512-XJGmq+4qVDqboH778pRVwpn2KKl/IHHNZnxiJO9HLDsK6OaF4yiY9NOFlfVCWCHt/NC8bfAxjACi/SDe/3TOJQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-1.9.0.tgz",
+      "integrity": "sha512-I2e3HEz9YavBU7YT9XY7ZBnoPAAFv45u8RKiX36gkHkr/K6NytjZGqrw6cbF0tCZdsdGq062TPKH6/ubkrJSxg==",
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -7883,6 +7869,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
     },
     "node_modules/hasown": {
       "version": "2.0.2",
@@ -10120,11 +10111,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw=="
-    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -11369,9 +11355,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sanity": {
-      "version": "3.41.1",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.41.1.tgz",
-      "integrity": "sha512-jCDEaGWV0Og5GWMeV+njcCcoSs+AmHLEaybmDUh7pTkPAhk451UDU0ooOHd7yqfp1tevHmuHVD2uhdnUthctWA==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.40.0.tgz",
+      "integrity": "sha512-QKWNu/lOD3UOfSflFKLoL7z1ZMe846OVuem2/VW6cLSXIOZJg0YxtmzvD0FxYAwB1D7o3MNcrv3b5wYlfBa5cA==",
       "dependencies": {
         "@dnd-kit/core": "^6.0.5",
         "@dnd-kit/modifiers": "^6.0.0",
@@ -11382,11 +11368,11 @@
         "@rexxars/react-json-inspector": "^8.0.1",
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/bifur-client": "^0.3.1",
-        "@sanity/block-tools": "3.41.1",
-        "@sanity/cli": "3.41.1",
-        "@sanity/client": "^6.17.2",
+        "@sanity/block-tools": "3.40.0",
+        "@sanity/cli": "3.40.0",
+        "@sanity/client": "^6.15.20",
         "@sanity/color": "^3.0.0",
-        "@sanity/diff": "3.41.1",
+        "@sanity/diff": "3.40.0",
         "@sanity/diff-match-patch": "^3.1.1",
         "@sanity/eventsource": "^5.0.0",
         "@sanity/export": "^3.37.4",
@@ -11394,15 +11380,15 @@
         "@sanity/image-url": "^1.0.2",
         "@sanity/import": "^3.37.3",
         "@sanity/logos": "^2.1.4",
-        "@sanity/migrate": "3.41.1",
-        "@sanity/mutator": "3.41.1",
-        "@sanity/portable-text-editor": "3.41.1",
-        "@sanity/presentation": "1.15.1",
-        "@sanity/schema": "3.41.1",
+        "@sanity/migrate": "3.40.0",
+        "@sanity/mutator": "3.40.0",
+        "@sanity/portable-text-editor": "3.40.0",
+        "@sanity/presentation": "1.12.10",
+        "@sanity/schema": "3.40.0",
         "@sanity/telemetry": "^0.7.6",
-        "@sanity/types": "3.41.1",
-        "@sanity/ui": "^2.1.6",
-        "@sanity/util": "3.41.1",
+        "@sanity/types": "3.40.0",
+        "@sanity/ui": "^2.1.4",
+        "@sanity/util": "3.40.0",
         "@sanity/uuid": "^3.0.1",
         "@tanstack/react-virtual": "3.0.0-beta.54",
         "@types/react-copy-to-clipboard": "^5.0.2",
@@ -11412,6 +11398,7 @@
         "@types/tar-stream": "^3.1.3",
         "@types/use-sync-external-store": "^0.0.6",
         "@vitejs/plugin-react": "^4.2.1",
+        "@vvo/tzdb": "^6.131.0",
         "archiver": "^7.0.0",
         "arrify": "^1.0.1",
         "async-mutex": "^0.4.1",
@@ -11424,15 +11411,17 @@
         "console-table-printer": "^2.11.1",
         "dataloader": "^2.1.0",
         "date-fns": "^2.26.1",
+        "date-fns-tz": "^2.0.0",
         "debug": "^4.3.4",
-        "esbuild": "^0.21.0",
+        "esbuild": "^0.20.0",
         "esbuild-register": "^3.4.1",
         "execa": "^2.0.0",
         "exif-component": "^1.0.1",
         "framer-motion": "11.0.8",
-        "get-it": "^8.4.28",
+        "get-it": "^8.4.27",
         "get-random-values-esm": "1.0.2",
         "groq-js": "^1.8.0",
+        "hashlru": "^2.3.0",
         "history": "^5.3.0",
         "i18next": "^23.2.7",
         "import-fresh": "^3.3.0",
@@ -11456,7 +11445,6 @@
         "pluralize-esm": "^9.0.2",
         "polished": "^4.2.2",
         "pretty-ms": "^7.0.1",
-        "quick-lru": "^5.1.1",
         "raf": "^3.4.1",
         "react-copy-to-clipboard": "^5.0.4",
         "react-fast-compare": "^3.2.0",
@@ -11476,6 +11464,7 @@
         "semver": "^7.3.5",
         "shallow-equals": "^1.0.0",
         "speakingurl": "^14.0.1",
+        "swr": "^2.2.5",
         "tar-fs": "^2.1.1",
         "tar-stream": "^3.1.7",
         "use-device-pixel-ratio": "^1.1.0",
@@ -11529,13 +11518,13 @@
       }
     },
     "node_modules/sanity/node_modules/@sanity/presentation": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@sanity/presentation/-/presentation-1.15.1.tgz",
-      "integrity": "sha512-bFghEY8rlUneLR5lWFXxdn52oMUwOrNucKrwinzykH9/m3NxrHA5ObvwoSu02lu+ebVLk0KY8ptczfoz6WDlWA==",
+      "version": "1.12.10",
+      "resolved": "https://registry.npmjs.org/@sanity/presentation/-/presentation-1.12.10.tgz",
+      "integrity": "sha512-wMEs5sF5wyXVZm/EMpt/eWriZDcoaCyeBTRffJLxSU2y1oGe9FIYAoUNPMU9AIRR/ZkJxwymWcsMQBC+nSlF/Q==",
       "dependencies": {
         "@sanity/icons": "^2.11.8",
-        "@sanity/preview-url-secret": "^1.6.12",
-        "@sanity/ui": "^2.1.6",
+        "@sanity/preview-url-secret": "^1.6.11",
+        "@sanity/ui": "^2.1.4",
         "@sanity/uuid": "3.0.2",
         "@types/lodash.isequal": "^4.5.8",
         "fast-deep-equal": "3.1.3",
@@ -11543,7 +11532,6 @@
         "lodash.isequal": "^4.5.0",
         "mendoza": "3.0.7",
         "mnemonist": "0.39.8",
-        "path-to-regexp": "^6.2.2",
         "rxjs": "^7.8.1",
         "suspend-react": "0.1.3"
       },
@@ -11551,25 +11539,25 @@
         "node": ">=16.14"
       },
       "peerDependencies": {
-        "@sanity/client": "^6.18.0"
+        "@sanity/client": "^6.15.20"
       }
     },
     "node_modules/sanity/node_modules/@sanity/types": {
-      "version": "3.41.1",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.41.1.tgz",
-      "integrity": "sha512-29pRfXQ6a89ozbZFQaUI/ldHde4bl/DL634CBj0gxTMYuFY7x/wLgCsjjDnMcJsB9Eiq+8enV8LNKdChGhW0Hg==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.40.0.tgz",
+      "integrity": "sha512-DS2QhzLFtb8Xc5Ur3pV5lE8Tk9CGwDmjOJUDMPDtgH9ESgiZgaC2TVsUHNX4e0s1kN2jzxH7q4gfFKFxKrX9yw==",
       "dependencies": {
-        "@sanity/client": "^6.17.2",
+        "@sanity/client": "^6.15.20",
         "@types/react": "^18.0.25"
       }
     },
     "node_modules/sanity/node_modules/@sanity/util": {
-      "version": "3.41.1",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.41.1.tgz",
-      "integrity": "sha512-rMOKJqXiJwLvGXx91SiAiBwV1pm4MelAfLOuld3wDWc4XANKSicfX2jcfLhgU3WprOM4aaOEumiA1JEnqdanaQ==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.40.0.tgz",
+      "integrity": "sha512-FfNxUfDfY2czVQnEDwDNMGaPgsxwZyh71De7KMQYs3GyZmPxlOdPipXkB18vlie2VycXnvm/i1gCSU3XxyxUAQ==",
       "dependencies": {
-        "@sanity/client": "^6.17.2",
-        "@sanity/types": "3.41.1",
+        "@sanity/client": "^6.15.20",
+        "@sanity/types": "3.40.0",
         "get-random-values-esm": "1.0.2",
         "moment": "^2.29.4",
         "rxjs": "^7.8.1"
@@ -11593,15 +11581,12 @@
         "url": "https://opencollective.com/date-fns"
       }
     },
-    "node_modules/sanity/node_modules/quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+    "node_modules/sanity/node_modules/date-fns-tz": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.1.tgz",
+      "integrity": "sha512-fJCG3Pwx8HUoLhkepdsP7Z5RsucUi+ZBOxyM5d0ZZ6c4SdYustq0VMmOu6Wf7bli+yS/Jwp91TOCqn9jMcVrUA==",
+      "peerDependencies": {
+        "date-fns": "2.x"
       }
     },
     "node_modules/sanity/node_modules/resolve-from": {
@@ -12367,6 +12352,18 @@
       "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
       "peerDependencies": {
         "react": ">=17.0"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.5.tgz",
+      "integrity": "sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==",
+      "dependencies": {
+        "client-only": "^0.0.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@sanity/demo": "2.0.0",
     "@sanity/icons": "2.11.8",
     "@sanity/image-url": "1.0.2",
-    "@sanity/presentation": "1.15.2",
     "@sanity/preview-url-secret": "1.6.12",
     "@sanity/react-loader": "1.9.18",
     "@sanity/ui": "2.1.7",
@@ -32,7 +31,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "rxjs": "7.8.1",
-    "sanity": "3.41.1",
+    "sanity": "3.40.0",
     "sanity-plugin-asset-source-unsplash": "3.0.1",
     "server-only": "0.0.1",
     "styled-components": "6.1.11"

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -3,9 +3,9 @@
  * This config is used to set up Sanity Studio that's mounted on the `app/studio/[[...index]]/Studio.tsx` route
  */
 
-import { presentationTool } from '@sanity/presentation'
 import { visionTool } from '@sanity/vision'
 import { defineConfig } from 'sanity'
+import { presentationTool } from 'sanity/presentation'
 import { structureTool } from 'sanity/structure'
 import { unsplashImageAsset } from 'sanity-plugin-asset-source-unsplash'
 

--- a/sanity/plugins/locate.ts
+++ b/sanity/plugins/locate.ts
@@ -1,8 +1,8 @@
+import { map, Observable } from 'rxjs'
 import {
   DocumentLocationResolver,
   DocumentLocationsState,
-} from '@sanity/presentation'
-import { map, Observable } from 'rxjs'
+} from 'sanity/presentation'
 
 import { resolveHref } from '@/sanity/lib/utils'
 


### PR DESCRIPTION
This, at the same time, requires `sanity` to be downgraded in order to not run into the `@sanity/presentation` state bug fixed in https://github.com/sanity-io/visual-editing/pull/1496.

By removing the direct dependency we eliminate the risk of too many people using this template with that in place. Using `@sanity/presentation` as a direct dependency, instead of the one reexported by `sanity`, can be risky because you need to manually keep it in line with whatever version `sanity` supports internally. Therefore, it's better to remove it and downgrade `sanity` and then wait a day or too until we can upgrade `sanity` and get back on the latest version of everything.