### PR TITLE
Add route-specific not found pages

### DIFF
--- a/app/(website)/[slug]/layout.tsx
+++ b/app/(website)/[slug]/layout.tsx
@@ -1,0 +1,8 @@
+export default function SlugLayout({children}: LayoutProps<'/[slug]'>) {
+  return (
+    <div>
+      <div className="mb-14">{children}</div>
+      <div className="absolute left-0 w-screen border-t" />
+    </div>
+  )
+}

--- a/app/(website)/[slug]/not-found.tsx
+++ b/app/(website)/[slug]/not-found.tsx
@@ -1,0 +1,17 @@
+import {Header} from '@/components/Header'
+import type {Metadata} from 'next'
+
+export const metadata: Metadata = {
+  title: '404 Page Not Found',
+}
+
+export default function SlugNotFound() {
+  return (
+    <>
+      <Header id={null} type={null} path={['overview']} title="404 Page Not Found" />
+      <p className="mt-6 max-w-3xl font-serif text-xl text-gray-600">
+        The page you&rsquo;re looking for doesn&rsquo;t exist or may have been moved.
+      </p>
+    </>
+  )
+}

--- a/app/(website)/[slug]/not-found.tsx
+++ b/app/(website)/[slug]/not-found.tsx
@@ -1,17 +1,5 @@
 import {Header} from '@/components/Header'
-import type {Metadata} from 'next'
-
-export const metadata: Metadata = {
-  title: '404 Page Not Found',
-}
 
 export default function SlugNotFound() {
-  return (
-    <>
-      <Header id={null} type={null} path={['overview']} title="404 Page Not Found" />
-      <p className="mt-6 max-w-3xl font-serif text-xl text-gray-600">
-        The page you&rsquo;re looking for doesn&rsquo;t exist or may have been moved.
-      </p>
-    </>
-  )
+  return <Header id={null} type={null} path={['overview']} title="404 Page Not Found" />
 }

--- a/app/(website)/[slug]/page.tsx
+++ b/app/(website)/[slug]/page.tsx
@@ -4,7 +4,6 @@ import {sanityFetch} from '@/sanity/lib/live'
 import {slugsByTypeQuery, type SlugsByTypeQueryParams} from '@/sanity/lib/queries'
 import type {Metadata, ResolvingMetadata} from 'next'
 import {defineQuery} from 'next-sanity'
-import {draftMode} from 'next/headers'
 import {notFound} from 'next/navigation'
 
 export async function generateStaticParams() {
@@ -54,37 +53,33 @@ export default async function SlugPage({params}: PageProps<'/[slug]'>) {
   const {slug} = await params
   const {data} = await sanityFetch({query: slugPageQuery, params: {slug}})
 
-  // Only show the 404 page if we're in production, when in draft mode we might be about to create a page on this slug, and live reload won't work on the 404 route
-  if (!data?._id && !(await draftMode()).isEnabled) {
+  if (!data?._id) {
     notFound()
   }
 
   const {body, overview, title} = data ?? {}
 
   return (
-    <div>
-      <div className="mb-14">
-        {/* Header */}
-        <Header
+    <>
+      {/* Header */}
+      <Header
+        id={data?._id || null}
+        type={data?._type || null}
+        path={['overview']}
+        title={title || 'Untitled'}
+        description={overview}
+      />
+
+      {/* Body */}
+      {Array.isArray(body) && (
+        <CustomPortableText
           id={data?._id || null}
           type={data?._type || null}
-          path={['overview']}
-          title={title || (data?._id ? 'Untitled' : '404 Page Not Found')}
-          description={overview}
+          path={['body']}
+          paragraphClasses="font-serif max-w-3xl text-gray-600 text-xl"
+          value={body}
         />
-
-        {/* Body */}
-        {Array.isArray(body) && (
-          <CustomPortableText
-            id={data?._id || null}
-            type={data?._type || null}
-            path={['body']}
-            paragraphClasses="font-serif max-w-3xl text-gray-600 text-xl"
-            value={body}
-          />
-        )}
-      </div>
-      <div className="absolute left-0 w-screen border-t" />
-    </div>
+      )}
+    </>
   )
 }

--- a/app/(website)/[slug]/page.tsx
+++ b/app/(website)/[slug]/page.tsx
@@ -53,9 +53,7 @@ export default async function SlugPage({params}: PageProps<'/[slug]'>) {
   const {slug} = await params
   const {data} = await sanityFetch({query: slugPageQuery, params: {slug}})
 
-  if (!data?._id) {
-    notFound()
-  }
+  if (!data?._id) notFound()
 
   const {body, overview, title} = data ?? {}
 

--- a/app/(website)/projects/[slug]/layout.tsx
+++ b/app/(website)/projects/[slug]/layout.tsx
@@ -1,0 +1,8 @@
+export default function ProjectSlugLayout({children}: LayoutProps<'/projects/[slug]'>) {
+  return (
+    <div>
+      <div className="mb-20 space-y-6">{children}</div>
+      <div className="absolute left-0 w-screen border-t" />
+    </div>
+  )
+}

--- a/app/(website)/projects/[slug]/not-found.tsx
+++ b/app/(website)/projects/[slug]/not-found.tsx
@@ -1,0 +1,29 @@
+import {Header} from '@/components/Header'
+import ImageBox from '@/components/ImageBox'
+import type {Metadata} from 'next'
+
+export const metadata: Metadata = {
+  title: '404 Project Not Found',
+}
+
+export default function ProjectSlugNotFound() {
+  return (
+    <>
+      <Header id={null} type={null} path={['overview']} title="404 Project Not Found" />
+
+      <div className="rounded-md border">
+        <ImageBox alt="" classesWrapper="relative aspect-[16/9]" />
+        <div className="divide-inherit grid grid-cols-1 divide-y lg:grid-cols-4 lg:divide-x lg:divide-y-0">
+          <div className="p-3 lg:p-4">
+            <div className="text-xs md:text-sm">Status</div>
+            <div className="text-md md:text-lg">Not found</div>
+          </div>
+        </div>
+      </div>
+
+      <p className="max-w-3xl font-serif text-xl text-gray-600">
+        The project you&rsquo;re looking for doesn&rsquo;t exist or may have been moved.
+      </p>
+    </>
+  )
+}

--- a/app/(website)/projects/[slug]/not-found.tsx
+++ b/app/(website)/projects/[slug]/not-found.tsx
@@ -1,29 +1,5 @@
 import {Header} from '@/components/Header'
-import ImageBox from '@/components/ImageBox'
-import type {Metadata} from 'next'
-
-export const metadata: Metadata = {
-  title: '404 Project Not Found',
-}
 
 export default function ProjectSlugNotFound() {
-  return (
-    <>
-      <Header id={null} type={null} path={['overview']} title="404 Project Not Found" />
-
-      <div className="rounded-md border">
-        <ImageBox alt="" classesWrapper="relative aspect-[16/9]" />
-        <div className="divide-inherit grid grid-cols-1 divide-y lg:grid-cols-4 lg:divide-x lg:divide-y-0">
-          <div className="p-3 lg:p-4">
-            <div className="text-xs md:text-sm">Status</div>
-            <div className="text-md md:text-lg">Not found</div>
-          </div>
-        </div>
-      </div>
-
-      <p className="max-w-3xl font-serif text-xl text-gray-600">
-        The project you&rsquo;re looking for doesn&rsquo;t exist or may have been moved.
-      </p>
-    </>
-  )
+  return <Header id={null} type={null} path={['overview']} title="404 Project Not Found" />
 }

--- a/app/(website)/projects/[slug]/page.tsx
+++ b/app/(website)/projects/[slug]/page.tsx
@@ -7,7 +7,6 @@ import {slugsByTypeQuery, type SlugsByTypeQueryParams} from '@/sanity/lib/querie
 import {urlForOpenGraphImage} from '@/sanity/lib/utils'
 import type {Metadata, ResolvingMetadata} from 'next'
 import {createDataAttribute, defineQuery} from 'next-sanity'
-import {draftMode} from 'next/headers'
 import Link from 'next/link'
 import {notFound} from 'next/navigation'
 
@@ -66,8 +65,7 @@ export default async function ProjectSlugPage({params}: PageProps<'/projects/[sl
   const {slug} = await params
   const {data} = await sanityFetch({query: projectSlugPageQuery, params: {slug}})
 
-  // Only show the 404 page if we're in production, when in draft mode we might be about to create a project on this slug, and live reload won't work on the 404 route
-  if (!data?._id && !(await draftMode()).isEnabled) {
+  if (!data?._id) {
     notFound()
   }
 
@@ -80,93 +78,89 @@ export default async function ProjectSlugPage({params}: PageProps<'/projects/[sl
         })
       : null
 
-  // Default to an empty object to allow previews on non-existent documents
   const {client, coverImage, description, duration, overview, site, tags, title} = data ?? {}
 
   const startYear = duration?.start ? new Date(duration.start).getFullYear() : undefined
   const endYear = duration?.end ? new Date(duration?.end).getFullYear() : 'Now'
 
   return (
-    <div>
-      <div className="mb-20 space-y-6">
-        {/* Header */}
-        <Header
-          id={data?._id || null}
-          type={data?._type || null}
-          path={['overview']}
-          title={title || (data?._id ? 'Untitled' : '404 Project Not Found')}
-          description={overview}
+    <>
+      {/* Header */}
+      <Header
+        id={data?._id || null}
+        type={data?._type || null}
+        path={['overview']}
+        title={title || 'Untitled'}
+        description={overview}
+      />
+
+      <div className="rounded-md border">
+        {/* Image  */}
+        <ImageBox
+          data-sanity={dataAttribute?.('coverImage')}
+          image={coverImage}
+          // @TODO add alt field in schema
+          alt=""
+          classesWrapper="relative aspect-[16/9]"
         />
 
-        <div className="rounded-md border">
-          {/* Image  */}
-          <ImageBox
-            data-sanity={dataAttribute?.('coverImage')}
-            image={coverImage}
-            // @TODO add alt field in schema
-            alt=""
-            classesWrapper="relative aspect-[16/9]"
-          />
-
-          <div className="divide-inherit grid grid-cols-1 divide-y lg:grid-cols-4 lg:divide-x lg:divide-y-0">
-            {/* Duration */}
-            {!!(startYear && endYear) && (
-              <div className="p-3 lg:p-4">
-                <div className="text-xs md:text-sm">Duration</div>
-                <div className="text-md md:text-lg">
-                  <span data-sanity={dataAttribute?.('duration.start')}>{startYear}</span>
-                  {' - '}
-                  <span data-sanity={dataAttribute?.('duration.end')}>{endYear}</span>
-                </div>
-              </div>
-            )}
-
-            {/* Client */}
-            {client && (
-              <div className="p-3 lg:p-4">
-                <div className="text-xs md:text-sm">Client</div>
-                <div className="text-md md:text-lg">{client}</div>
-              </div>
-            )}
-
-            {/* Site */}
-            {site && (
-              <div className="p-3 lg:p-4">
-                <div className="text-xs md:text-sm">Site</div>
-                {site && (
-                  <Link target="_blank" className="text-md break-words md:text-lg" href={site}>
-                    {site}
-                  </Link>
-                )}
-              </div>
-            )}
-
-            {/* Tags */}
+        <div className="divide-inherit grid grid-cols-1 divide-y lg:grid-cols-4 lg:divide-x lg:divide-y-0">
+          {/* Duration */}
+          {!!(startYear && endYear) && (
             <div className="p-3 lg:p-4">
-              <div className="text-xs md:text-sm">Tags</div>
-              <div className="text-md flex flex-row flex-wrap md:text-lg">
-                {tags?.map((tag, key) => (
-                  <div key={key} className="mr-1 break-words">
-                    #{tag}
-                  </div>
-                ))}
+              <div className="text-xs md:text-sm">Duration</div>
+              <div className="text-md md:text-lg">
+                <span data-sanity={dataAttribute?.('duration.start')}>{startYear}</span>
+                {' - '}
+                <span data-sanity={dataAttribute?.('duration.end')}>{endYear}</span>
               </div>
+            </div>
+          )}
+
+          {/* Client */}
+          {client && (
+            <div className="p-3 lg:p-4">
+              <div className="text-xs md:text-sm">Client</div>
+              <div className="text-md md:text-lg">{client}</div>
+            </div>
+          )}
+
+          {/* Site */}
+          {site && (
+            <div className="p-3 lg:p-4">
+              <div className="text-xs md:text-sm">Site</div>
+              {site && (
+                <Link target="_blank" className="text-md break-words md:text-lg" href={site}>
+                  {site}
+                </Link>
+              )}
+            </div>
+          )}
+
+          {/* Tags */}
+          <div className="p-3 lg:p-4">
+            <div className="text-xs md:text-sm">Tags</div>
+            <div className="text-md flex flex-row flex-wrap md:text-lg">
+              {tags?.map((tag, key) => (
+                <div key={key} className="mr-1 break-words">
+                  #{tag}
+                </div>
+              ))}
             </div>
           </div>
         </div>
-
-        {/* Description */}
-        {Array.isArray(description) && (
-          <CustomPortableText
-            id={data?._id || null}
-            type={data?._type || null}
-            path={['description']}
-            paragraphClasses="font-serif max-w-3xl text-xl text-gray-600"
-            value={description}
-          />
-        )}
       </div>
-      <div className="absolute left-0 w-screen border-t" />
-    </div>
+
+      {/* Description */}
+      {Array.isArray(description) && (
+        <CustomPortableText
+          id={data?._id || null}
+          type={data?._type || null}
+          path={['description']}
+          paragraphClasses="font-serif max-w-3xl text-xl text-gray-600"
+          value={description}
+        />
+      )}
+    </>
   )
 }

--- a/app/(website)/projects/[slug]/page.tsx
+++ b/app/(website)/projects/[slug]/page.tsx
@@ -65,9 +65,7 @@ export default async function ProjectSlugPage({params}: PageProps<'/projects/[sl
   const {slug} = await params
   const {data} = await sanityFetch({query: projectSlugPageQuery, params: {slug}})
 
-  if (!data?._id) {
-    notFound()
-  }
+  if (!data?._id) notFound()
 
   const dataAttribute =
     data?._id && data._type


### PR DESCRIPTION
## Summary
- Add segment-specific 404 pages for content and project routes.
- Always call `notFound()` for missing Sanity documents, including draft mode.
- Move shared route wrapper markup into sibling layouts.

## Test plan
- npm run type-check
- npm run lint


Made with [Cursor](https://cursor.com)