### PR TITLE
Skill eval: sanity-live-cache-components (PR #3581 draft)

### DIFF
--- a/.agents/skills/sanity-live-cache-components/SKILL.md
+++ b/.agents/skills/sanity-live-cache-components/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: sanity-live-cache-components
+description: Integrates Sanity Live with Next.js Cache Components in next-sanity v13+ apps. Sets up sanityFetch, <SanityLive>, Visual Editing, Presentation Tool, draft mode handling, and the three-layer (Page/Dynamic/Cached) component pattern with explicit perspective/stega prop-drilling. Use when configuring or migrating a Next.js app to cacheComponents with Sanity, when adding sanityFetch, when wiring <SanityLive>/<VisualEditing>, or when refactoring components that hardcode perspective/stega.
+---
+
+# Sanity Live + Cache Components
+
+Wires `next-sanity` into a Next.js 16+ app with `cacheComponents: true`. Data is fetched with `sanityFetch` (which calls `cacheTag`/`cacheLife` internally), and `<SanityLive>` in the root layout revalidates cached content over an EventSource connection to Sanity Content Lake. Visual Editing and Presentation Tool are fully supported when draft mode is enabled.
+
+Read the relevant guide in `node_modules/next/dist/docs/` (when available) before writing code. If a guide conflicts with this skill, follow this skill.
+
+This skill assumes familiarity with the `next-cache-components` skill — it covers `'use cache'`, `cacheLife`, `cacheTag`, and the cookies/headers/params rule. The only Sanity-relevant exception: `await draftMode()` is allowed inside `'use cache'` (Next.js bypasses caching when draft mode is enabled — see [the `use cache` reference](https://nextjs.org/docs/app/api-reference/directives/use-cache#draft-mode)).
+
+## Prerequisites
+
+- Next.js 16.2+ (`pnpm view next version` or `npm view next version` to check).
+- `AGENTS.md` exists, or [follow the guide](https://nextjs.org/docs/app/guides/ai-agents#existing-projects).
+- These environment variables are set:
+  - `NEXT_PUBLIC_SANITY_PROJECT_ID`
+  - `NEXT_PUBLIC_SANITY_DATASET`
+  - `SANITY_API_READ_TOKEN`
+
+## Reference files
+
+| File                                                          | When to read                                                                          |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [reference/live-helpers.md](reference/live-helpers.md)        | Full `client.ts` / `live.ts`, `sanityFetch*` and `getDynamicFetchOptions` details     |
+| [reference/three-layer-pattern.md](reference/three-layer-pattern.md) | The Page → Dynamic → Cached pattern for `page.tsx`, including the `searchParams` variant |
+| [reference/layouts.md](reference/layouts.md)                  | Non-blocking data fetching inside `layout.tsx` with a shared `'use cache'` helper     |
+| [reference/dynamic-segments.md](reference/dynamic-segments.md) | High-performance `[slug]` routes: `loading.tsx` + partial `generateStaticParams`, or non-blocking dynamic `params` in a layout |
+
+---
+
+## 1. Install `next-sanity@^13`
+
+```bash
+npm install next-sanity@^13 --save-exact
+```
+
+If `next-sanity@latest` isn't v13 yet, use `next-sanity@cache-components` instead. Check with `npm dist-tag ls next-sanity`.
+
+### Migrating an existing Sanity Live setup
+
+If the app is already using `defineLive`, this skill is a refactor, not a rewrite. The 5-step sequence below still applies, but watch for these specific differences:
+
+- **Don't overwrite `client.ts` or `live.ts`** if they exist. Append missing options. Preserve any existing `token` and `stega.*` settings — see [reference/live-helpers.md](reference/live-helpers.md).
+- **Search the codebase for hardcoded `perspective: 'published'` and `stega: false`** in `sanityFetch` callsites and refactor them to source `perspective`/`stega` via `getDynamicFetchOptions` and the three-layer pattern.
+- **Search for `sanityFetch` calls inside `generateStaticParams`** → swap for `sanityFetchStaticParams`.
+- **Search for `sanityFetch` calls inside `generateMetadata` / `sitemap.ts` / `opengraph-image.tsx` / etc.** → swap for `sanityFetchMetadata`.
+- **Search for `sanityFetch` calls directly inside a `'use server'` function** → split into a separate `'use cache'` helper.
+- **Verify there is exactly one `<SanityLive>` and one `<VisualEditing>` in the tree.** Multiple renders are undefined behavior.
+
+The "Anti-patterns to grep for" section at the bottom of this file lists the search patterns.
+
+---
+
+## 2. Configure `next.config.ts`
+
+Enable `cacheComponents` and set `cacheLife.default` to `sanity` so default revalidation is 1 year (instead of 15 minutes). `sanityFetch` is optimized for on-demand revalidation and doesn't need time-based revalidation.
+
+```ts
+// next.config.ts
+import type {NextConfig} from 'next'
+import {sanity} from 'next-sanity/live/cache-life'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  cacheLife: {default: sanity},
+}
+
+export default nextConfig
+```
+
+---
+
+## 3. Configure `defineLive` and export helpers
+
+Create `src/sanity/lib/client.ts` and `src/sanity/lib/live.ts`. The minimal `defineLive` call:
+
+```ts
+// src/sanity/lib/live.ts (excerpt)
+export const {SanityLive, sanityFetch} = defineLive({
+  client,
+  serverToken: token,
+  browserToken: token,
+  strict: true,
+})
+```
+
+Full file contents (including `client.ts`, `getDynamicFetchOptions`, `sanityFetchMetadata`, `sanityFetchStaticParams`) and per-helper guidance: [reference/live-helpers.md](reference/live-helpers.md).
+
+The helpers exported from `live.ts`:
+
+| Helper                     | Used in                                                              |
+| -------------------------- | -------------------------------------------------------------------- |
+| `sanityFetch`              | `'use cache'` components rendered from `page.tsx` / `layout.tsx`     |
+| `sanityFetchMetadata`      | `generateMetadata`, `generateViewport`, `sitemap.ts`, `robots.ts`, `opengraph-image.tsx`, etc. |
+| `sanityFetchStaticParams`  | `generateStaticParams` only                                          |
+| `getDynamicFetchOptions`   | Resolving `perspective`/`stega` outside any `'use cache'` boundary   |
+| `SanityLive`               | Rendered once in a root layout                                       |
+
+---
+
+## 4. Render `<SanityLive>` in a root layout
+
+`<SanityLive>` and `<VisualEditing>` both belong in a `layout.tsx`, never a `page.tsx`. Both must be rendered at most once across the whole tree — duplicate renders are undefined behavior.
+
+```tsx
+// src/app/layout.tsx
+import {SanityLive} from '@/sanity/lib/live'
+import {VisualEditing} from 'next-sanity/visual-editing'
+import {draftMode} from 'next/headers'
+
+export default async function RootLayout({children}: LayoutProps<'/'>) {
+  const {isEnabled: isDraftMode} = await draftMode()
+  return (
+    <html lang="en">
+      <body>
+        {children}
+        <SanityLive includeDrafts={isDraftMode} />
+        {isDraftMode && <VisualEditing />}
+      </body>
+    </html>
+  )
+}
+```
+
+### With an embedded Sanity Studio
+
+If a route mounts `NextStudio` from `next-sanity/studio` (e.g. `app/studio/[[...index]]/page.tsx`), `<SanityLive>` must live in a layout the embedded studio doesn't share. Use [route groups](https://nextjs.org/docs/app/api-reference/file-conventions/route-groups): put `<SanityLive>` in `src/app/(website)/layout.tsx` and keep the rest of the app under `src/app/(website)`.
+
+---
+
+## 5. Apply the three-layer pattern to pages and layouts
+
+Every route that should be statically prerendered uses the same shape:
+
+```text
+Page/Layout (Layer 1: draftMode branch)
+  ├── NOT draft mode → <CachedX perspective="published" stega={false} />  (no Suspense)
+  └── draft mode → <Suspense fallback={...}>
+                      <DynamicX params={params} />  (Layer 2: awaits dynamic APIs)
+                        └── <CachedX perspective={p} stega={s} />  (Layer 3: 'use cache')
+```
+
+Pick the right reference for the file you're editing:
+
+- **`page.tsx`** with static or `generateStaticParams`-backed params → [reference/three-layer-pattern.md](reference/three-layer-pattern.md).
+- **`page.tsx`** that uses `searchParams` or other dynamic APIs → the `searchParams` variant in [reference/three-layer-pattern.md](reference/three-layer-pattern.md).
+- **`layout.tsx`** that fetches its own data → [reference/layouts.md](reference/layouts.md).
+- **Dynamic `[slug]` route** that needs the `loading.tsx` + partial `generateStaticParams` optimization, or a layout that needs non-blocking `params` → [reference/dynamic-segments.md](reference/dynamic-segments.md).
+
+---
+
+## Anti-patterns to grep for
+
+When auditing an app, search for these and refactor:
+
+- `perspective: 'published'` and `stega: false` hardcoded together in a `sanityFetch` call → use the three-layer pattern, source `perspective`/`stega` via `getDynamicFetchOptions`.
+- `sanityFetch(` directly inside a function whose body begins with `'use server'` → split into a separate `'use cache'` helper.
+- `sanityFetch(` inside `generateStaticParams` → swap for `sanityFetchStaticParams`.
+- `sanityFetch(` inside `generateMetadata` / `generateViewport` / `sitemap.ts` / `robots.ts` / `opengraph-image.tsx` etc. → swap for `sanityFetchMetadata` and resolve `perspective` via `getDynamicFetchOptions`.
+- `await draftMode()` immediately followed by `await getDynamicFetchOptions()` at the top of a `page.tsx` or `layout.tsx` without a sibling `loading.tsx` → move those dynamic-API calls into a child component wrapped in `<Suspense>` so the static shell can prerender.
+- More than one `<SanityLive>` or `<VisualEditing>` rendered in the tree → consolidate to a single render in the right layout.

--- a/.agents/skills/sanity-live-cache-components/reference/dynamic-segments.md
+++ b/.agents/skills/sanity-live-cache-components/reference/dynamic-segments.md
@@ -1,0 +1,103 @@
+# High-performance dynamic segments
+
+[Dynamic routes](https://nextjs.org/docs/app/api-reference/file-conventions/dynamic-routes) should always implement `generateStaticParams`, even if only a subset of pages — see [the Cache Components note on dynamic routes](https://nextjs.org/docs/app/api-reference/file-conventions/dynamic-routes#with-cache-components). Whether to use `loading.tsx` or `<Suspense>` for fallback UI depends on the use case — see [the streaming guide](https://nextjs.org/docs/app/guides/streaming#when-to-use-loadingjs-vs-suspense).
+
+## Contents
+
+- [Case 1: `page.tsx` with `loading.tsx` + partial `generateStaticParams`](#case-1-pagetsx-with-loadingtsx--partial-generatestaticparams)
+- [Case 2: `layout.tsx` with non-blocking dynamic `params`](#case-2-layouttsx-with-non-blocking-dynamic-params)
+
+## Case 1: `page.tsx` with `loading.tsx` + partial `generateStaticParams`
+
+`generateStaticParams` returns only the 100 most recently updated pages. A sibling `loading.tsx` renders fallback UI, so `page.tsx` itself can skip the `<Suspense>` wrapper. The same fallback UI is reused in draft mode.
+
+This scales to thousands of pages without ballooning `next build` and without compromising UX in production:
+
+- Prerendered pages load instantly.
+- Pages not prerendered start rendering on `<Link>` hover (or when scrolled into view), so on click:
+  - If prerendering finished in time → serves instantly, no loading state.
+  - If not → instantly shows the cached `loading.tsx` fallback.
+
+Add a sibling `src/app/[slug]/loading.tsx` that renders the same skeleton you would otherwise pass to `<Suspense>`.
+
+```tsx
+// src/app/[slug]/page.tsx
+import {
+  getDynamicFetchOptions,
+  sanityFetch,
+  sanityFetchStaticParams,
+  type DynamicFetchOptions,
+} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+
+export async function generateStaticParams() {
+  const pageSlugsQuery = defineQuery(
+    `*[_type == "page" && defined(slug.current)] | order(_updatedAt desc) [0...100]{"slug": slug.current}`,
+  )
+  const {data} = await sanityFetchStaticParams({query: pageSlugsQuery})
+  return data
+}
+
+// With sibling `loading.tsx`, skip the `<Suspense>` + `DynamicPage` indirection: await `params`
+// and `getDynamicFetchOptions` directly inside `Page`.
+export default async function Page({params}: PageProps<'/[slug]'>) {
+  const [{slug}, {perspective, stega}] = await Promise.all([params, getDynamicFetchOptions()])
+  return <CachedPage slug={slug} perspective={perspective} stega={stega} />
+}
+async function CachedPage({
+  slug,
+  perspective,
+  stega,
+}: Awaited<PageProps<'/[slug]'>['params']> & DynamicFetchOptions) {
+  'use cache'
+  const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
+  const {data} = await sanityFetch({
+    query: pageQuery,
+    params: {slug},
+    perspective,
+    stega,
+  })
+  return <article>{/* use `data` to render stuff */}</article>
+}
+```
+
+## Case 2: `layout.tsx` with non-blocking dynamic `params`
+
+A `layout.tsx` can't use `loading.tsx` for fallback UI — [it's one level higher in the hierarchy](https://nextjs.org/docs/app/getting-started/project-structure#component-hierarchy). To fetch data that depends on dynamic `params` without blocking `children` from streaming, pass the unawaited `params` promise into a `<Suspense>` boundary and await it inside.
+
+```tsx
+// src/app/(website)/[slug]/layout.tsx
+
+import {getDynamicFetchOptions, sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+import {Suspense} from 'react'
+
+export default function WebsiteLayout({children, params}: LayoutProps<'/[slug]'>) {
+  return (
+    <>
+      {children}
+      {/* The footer renders below the fold, no fallback needed */}
+      <Suspense>
+        <DynamicFooter
+          // Don't await `params` here — pass the promise and await inside Suspense so `children` streams in parallel
+          params={params}
+        />
+      </Suspense>
+    </>
+  )
+}
+async function DynamicFooter({params}: Pick<LayoutProps<'/[slug]'>, 'params'>) {
+  const [{slug}, {perspective, stega}] = await Promise.all([params, getDynamicFetchOptions()])
+  return <Footer slug={slug} perspective={perspective} stega={stega} />
+}
+async function Footer({
+  slug,
+  perspective,
+  stega,
+}: Awaited<LayoutProps<'/[slug]'>['params']> & DynamicFetchOptions) {
+  'use cache'
+  const footerQuery = defineQuery(`*[_type == "footer" && slug.current == $slug][0]`)
+  const {data} = await sanityFetch({query: footerQuery, params: {slug}, perspective, stega})
+  return <footer>{/* use `data` to render stuff */}</footer>
+}
+```

--- a/.agents/skills/sanity-live-cache-components/reference/layouts.md
+++ b/.agents/skills/sanity-live-cache-components/reference/layouts.md
@@ -1,0 +1,163 @@
+# Non-blocking layout patterns
+
+When `sanityFetch` runs inside a `layout.tsx`, the goal is to keep `children` streaming and keep the static shell as large as possible.
+
+## Contents
+
+- [Rules](#rules)
+- [Pattern: shared `'use cache'` helper per draft/published branch](#pattern-shared-use-cache-helper-per-draftpublished-branch)
+- [Anti-pattern: wrapping `children` in a single cached layout](#anti-pattern-wrapping-children-in-a-single-cached-layout)
+- [Simpler example: a single `<Footer>`](#simpler-example-a-single-footer)
+
+## Rules
+
+- The top-level `layout.tsx` component must not `await` dynamic APIs or fetch data. Either reduces the static shell or slows draft-mode streaming.
+- Push [dynamic API calls](https://nextjs.org/docs/app/guides/streaming#push-dynamic-access-down) down to the leaf that needs them.
+- Extract shared data fetching into a reusable async `'use cache'` helper so two components that need the same data don't both wait independently.
+
+## Pattern: shared `'use cache'` helper per draft/published branch
+
+```tsx
+// src/app/(website)/layout.tsx
+import {getDynamicFetchOptions, sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+import {draftMode} from 'next/headers'
+import {Suspense} from 'react'
+
+async function fetchSettings({perspective, stega}: DynamicFetchOptions) {
+  'use cache'
+  const settingsQuery = defineQuery(`*[_type == "settings"][0]`)
+  const {data} = await sanityFetch({query: settingsQuery, perspective, stega})
+  return data
+}
+
+export default async function WebsiteLayout({children}: LayoutProps<'/'>) {
+  const {isEnabled: isDraftMode} = await draftMode()
+  return (
+    <>
+      {isDraftMode ? (
+        <Suspense fallback={<NavbarFallback />}>
+          <DynamicNavbar />
+        </Suspense>
+      ) : (
+        <CachedNavbar perspective="published" stega={false} />
+      )}
+      {children}
+      {isDraftMode ? (
+        <Suspense>
+          <DynamicFooter />
+        </Suspense>
+      ) : (
+        <CachedFooter perspective="published" stega={false} />
+      )}
+    </>
+  )
+}
+
+async function DynamicNavbar() {
+  const {perspective, stega} = await getDynamicFetchOptions()
+  return <CachedNavbar perspective={perspective} stega={stega} />
+}
+async function CachedNavbar({perspective, stega}: DynamicFetchOptions) {
+  'use cache'
+  const data = await fetchSettings({perspective, stega})
+  return <Navbar data={data} />
+}
+
+async function DynamicFooter() {
+  const {perspective, stega} = await getDynamicFetchOptions()
+  return <CachedFooter perspective={perspective} stega={stega} />
+}
+async function CachedFooter({perspective, stega}: DynamicFetchOptions) {
+  'use cache'
+  const data = await fetchSettings({perspective, stega})
+  return <Footer data={data} />
+}
+```
+
+## Anti-pattern: wrapping `children` in a single cached layout
+
+This blocks `children` on the layout's data fetch and prevents the page itself from streaming in independently.
+
+```tsx
+// src/app/(website)/layout.tsx
+export default async function WebsiteLayout({children}: LayoutProps<'/'>) {
+  const {isEnabled: isDraftMode} = await draftMode()
+  if (isDraftMode) {
+    return (
+      <Suspense>
+        <DynamicWebsiteLayout>{children}</DynamicWebsiteLayout>
+      </Suspense>
+    )
+  }
+  return (
+    <CachedWebsiteLayout perspective="published" stega={false}>
+      {children}
+    </CachedWebsiteLayout>
+  )
+}
+async function CachedWebsiteLayout({
+  children,
+  perspective,
+  stega,
+}: {children: ReactNode} & DynamicFetchOptions) {
+  'use cache'
+  const settingsQuery = defineQuery(`*[_type == "settings"][0]`)
+  const {data} = await sanityFetch({query: settingsQuery, perspective, stega})
+
+  return (
+    <>
+      <Navbar data={data} />
+      {children}
+      <Footer data={data} />
+    </>
+  )
+}
+```
+
+## Simpler example: a single `<Footer>`
+
+Useful as a sanity check when adapting the pattern to a layout with only one data-driven section:
+
+```tsx
+// src/app/(website)/layout.tsx
+import {getDynamicFetchOptions, sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+import {draftMode} from 'next/headers'
+import {Suspense} from 'react'
+
+export default async function WebsiteLayout({children}: LayoutProps<'/'>) {
+  const {isEnabled: isDraftMode} = await draftMode()
+  return (
+    <>
+      {children}
+      {isDraftMode ? (
+        <Suspense fallback={<FooterFallback />}>
+          <DynamicFooter />
+        </Suspense>
+      ) : (
+        <Footer perspective="published" stega={false} />
+      )}
+    </>
+  )
+}
+async function DynamicFooter() {
+  const {perspective, stega} = await getDynamicFetchOptions()
+  return <Footer perspective={perspective} stega={stega} />
+}
+async function Footer({perspective, stega}: DynamicFetchOptions) {
+  'use cache'
+  const footerQuery = defineQuery(`*[_type == "footer"][0]`)
+  const {data} = await sanityFetch({query: footerQuery, perspective, stega})
+  return <footer>{/* use `data` to render stuff */}</footer>
+}
+function FooterFallback() {
+  return (
+    <footer>
+      <p>Loading footer...</p>
+    </footer>
+  )
+}
+```
+
+The non-draft `<Footer perspective="published" stega={false} />` is part of the static shell, so the whole layout is cached and revalidates only when content used by `sanityFetch` changes. In draft mode the layout still renders immediately from its static shell while `<DynamicFooter>` streams in.

--- a/.agents/skills/sanity-live-cache-components/reference/live-helpers.md
+++ b/.agents/skills/sanity-live-cache-components/reference/live-helpers.md
@@ -1,0 +1,214 @@
+# Live helpers: `client.ts` and `live.ts`
+
+## Contents
+
+- [`client.ts`](#clientts)
+- [`live.ts`](#livets)
+- [`sanityFetch`](#sanityfetch)
+- [`sanityFetchMetadata`](#sanityfetchmetadata)
+- [`getDynamicFetchOptions`](#getdynamicfetchoptions)
+- [`sanityFetchStaticParams`](#sanityfetchstaticparams)
+- [Anti-patterns to grep for](#anti-patterns-to-grep-for)
+
+## `client.ts`
+
+Projects typically have a `src/sanity/lib/client.ts` that exports a `createClient` instance:
+
+```ts
+// src/sanity/lib/client.ts
+import {createClient} from 'next-sanity'
+
+export const client = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET!,
+  useCdn: true,
+  apiVersion: '2026-05-19',
+  perspective: 'published',
+  stega: {studioUrl: process.env.NEXT_PUBLIC_SANITY_STUDIO_URL || 'http://localhost:3333'},
+})
+```
+
+- Use a modern `apiVersion` (e.g. today's date as a hardcoded string).
+- `stega.studioUrl` enables stega encoding. It can be a relative string when an embedded Studio is mounted via `NextStudio` from `next-sanity/studio`, otherwise an absolute URL (typically env-driven).
+- If `client.ts` already exists, **append** missing options rather than overwriting. Changing `apiVersion` or removing existing `stega.*` options can break callers.
+- Never remove an existing `token` from `createClient`. Private datasets require a client token even for published-content fetches.
+
+## `live.ts`
+
+Create `src/sanity/lib/live.ts` alongside `client.ts`. If it already exists, append only what's missing.
+
+```ts
+// src/sanity/lib/live.ts
+import {type QueryParams} from 'next-sanity'
+import {defineLive, resolvePerspectiveFromCookies, type LivePerspective} from 'next-sanity/live'
+import {cookies, draftMode} from 'next/headers'
+import {client} from './client'
+
+const token = process.env.SANITY_API_READ_TOKEN
+if (!token) {
+  throw new Error('Missing SANITY_API_READ_TOKEN')
+}
+
+export const {SanityLive, sanityFetch} = defineLive({
+  client,
+  serverToken: token,
+  browserToken: token,
+  strict: true,
+})
+
+export interface DynamicFetchOptions {
+  perspective: LivePerspective
+  stega: boolean
+}
+export async function getDynamicFetchOptions(): Promise<DynamicFetchOptions> {
+  const {isEnabled: isDraftMode} = await draftMode()
+  if (!isDraftMode) {
+    return {perspective: 'published', stega: false}
+  }
+
+  const jar = await cookies()
+  const perspective = await resolvePerspectiveFromCookies({cookies: jar})
+  return {perspective: perspective ?? 'drafts', stega: true}
+}
+
+// For usage within `generateStaticParams`
+export async function sanityFetchStaticParams<const QueryString extends string>({
+  query,
+  params = {},
+}: {
+  query: QueryString
+  params?: QueryParams
+}) {
+  'use cache'
+  const {data} = await sanityFetch({query, params, perspective: 'published', stega: false})
+  return {data}
+}
+
+// For usage within `generateMetadata` and `generateViewport`
+export async function sanityFetchMetadata<const QueryString extends string>({
+  query,
+  params = {},
+  perspective,
+}: {
+  query: QueryString
+  params?: QueryParams
+  perspective: LivePerspective
+}) {
+  'use cache'
+  const {data} = await sanityFetch({query, params, perspective, stega: false})
+  return {data}
+}
+```
+
+## `sanityFetch`
+
+For fetching data in React Server Components that have a `'use cache'` directive and are rendered (directly or transitively) from a `page.tsx` or `layout.tsx`.
+
+- `perspective` switches between published, drafts, and specific Sanity Content Releases.
+- `stega: true` (combined with `stega.studioUrl` in `createClient` and `<VisualEditing>` in the root layout) renders click-to-edit overlays.
+- `getDynamicFetchOptions` resolves `perspective` from the `sanity-preview-perspective` cookie, which `<VisualEditing>` manages when the app is rendered inside Presentation Tool's preview iframe.
+
+The async function that calls `sanityFetch` must carry `'use cache'` or `'use cache: remote'`, and must take `perspective` and `stega` as props. Never hardcode them.
+
+Pattern:
+
+```tsx
+import {sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+
+async function CachedComponent({slug, perspective, stega}: {slug: string} & DynamicFetchOptions) {
+  'use cache'
+  const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
+  const {data} = await sanityFetch({query: pageQuery, params: {slug}, perspective, stega})
+}
+```
+
+Anti-pattern (hardcoded options break Visual Editing and content-release previewing):
+
+```tsx
+async function CachedComponent({slug}: {slug: string}) {
+  'use cache'
+  const {data} = await sanityFetch({
+    query: pageQuery,
+    params: {slug},
+    perspective: 'published', // hardcoded
+    stega: false, // hardcoded
+  })
+}
+```
+
+### `sanityFetch` inside server actions
+
+`'use server'` boundaries cannot accept `perspective`/`stega` as props (server action inputs are untrusted). Resolve them inside the `'use server'` function and forward them to a separate `'use cache'` boundary:
+
+```tsx
+import {getDynamicFetchOptions, sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+
+async function fetchMore({page, perspective, stega}: {page: string} & DynamicFetchOptions) {
+  'use cache'
+  const pagesQuery = defineQuery(`*[_type == "page"][0...$page]`)
+  const {data} = await sanityFetch({query: pagesQuery, params: {page}, perspective, stega})
+  return data
+}
+async function renderMore({page}: {page: string}) {
+  'use server'
+  const {perspective, stega} = await getDynamicFetchOptions()
+  const data = await fetchMore({page, perspective, stega})
+}
+```
+
+Anti-patterns:
+
+- Hardcoding `perspective`/`stega` in the `'use cache'` helper.
+- Calling `sanityFetch` directly inside `'use server'` — it bypasses caching entirely.
+
+### `sanityFetch` inside `route.ts`
+
+Hardcode `stega: false` and resolve only `perspective`. Route handlers don't render a DOM next to `<VisualEditing>`, so stega encoding only inflates the payload (and can cause downstream errors).
+
+## `sanityFetchMetadata`
+
+For fetching data inside `generateMetadata`, `generateSitemaps`, `generateViewport`, `generateImageMetadata`, and the file-based metadata routes (`icon.tsx`, `apple-icon.tsx`, `manifest.ts`, `opengraph-image.tsx`, `twitter-image.tsx`, `robots.ts`, `sitemap.ts`).
+
+It's `sanityFetch` without `stega` (never wanted in these contexts) and without requiring `'use cache'` at the callsite — the helper already provides it.
+
+Presentation Tool can open an app in a standalone preview window, so the correct content release must still be reflected in `<title>` and friends. Always resolve `perspective`:
+
+```ts
+import {getDynamicFetchOptions, sanityFetchMetadata} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+
+export async function generateMetadata({params}: PageProps<'/[slug]'>) {
+  const [{slug}, {perspective}] = await Promise.all([params, getDynamicFetchOptions()])
+  const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
+  const {data} = await sanityFetchMetadata({query: pageQuery, params: {slug}, perspective})
+}
+```
+
+Anti-pattern: hardcoding `perspective: 'published'` — content-release previewing won't work.
+
+## `getDynamicFetchOptions`
+
+Resolves `perspective` and `stega` outside the `'use cache'` boundary so they can be passed in as plain props. Calls `cookies()`, which is a dynamic API, so the call must live inside a `<Suspense>` boundary (or a route with a sibling `loading.tsx`) so it doesn't block the static shell from streaming.
+
+Avoid calling `getDynamicFetchOptions` in the top-level body of a `layout.tsx` or `page.tsx` that should remain part of the static shell. The exception is routes that intentionally use a sibling `loading.tsx` for fallback UI (see [dynamic-segments.md](dynamic-segments.md)) — there the page can await `getDynamicFetchOptions` directly because `loading.tsx` provides the streaming fallback.
+
+When Cache Components are enabled, `<Suspense>` boundaries determine the static shell. For fully prerendered routes, render the Suspense tree only when in draft mode — see [three-layer-pattern.md](three-layer-pattern.md).
+
+## `sanityFetchStaticParams`
+
+Used inside `generateStaticParams`. `stega` is never wanted (the data feeds route params), and `perspective` cookies aren't available at build time anyway, so both are hardcoded.
+
+- Never call `sanityFetch` inside `generateStaticParams` — always use `sanityFetchStaticParams`.
+- Never call `sanityFetchStaticParams` outside `generateStaticParams`.
+
+## Anti-patterns to grep for
+
+When migrating an existing app, these are the strings to search for and refactor:
+
+- `perspective: 'published'` and `stega: false` hardcoded together in a `sanityFetch` call → replace with `perspective` and `stega` props sourced from `getDynamicFetchOptions` via the three-layer pattern.
+- `sanityFetch(` directly inside a function whose body starts with `'use server'` → split into a separate `'use cache'` helper and forward `perspective`/`stega` as props.
+- `sanityFetch(` inside `generateStaticParams` → swap for `sanityFetchStaticParams`.
+- `sanityFetch(` inside `generateMetadata` / `generateViewport` / `sitemap.ts` / `robots.ts` / `opengraph-image.tsx` etc. → swap for `sanityFetchMetadata` and resolve `perspective` via `getDynamicFetchOptions`.
+- `await draftMode()` immediately followed by `await getDynamicFetchOptions()` at the top of a `page.tsx` or `layout.tsx` without a sibling `loading.tsx` → move the dynamic-API calls into a child component wrapped in `<Suspense>` so the static shell can prerender.

--- a/.agents/skills/sanity-live-cache-components/reference/three-layer-pattern.md
+++ b/.agents/skills/sanity-live-cache-components/reference/three-layer-pattern.md
@@ -1,0 +1,146 @@
+# Three-layer component pattern
+
+The core architecture for every route that can be fully statically prerendered and cached.
+
+## Contents
+
+- [Structure](#structure)
+- [`generateStaticParams` for dynamic routes](#generatestaticparams-for-dynamic-routes)
+- [Layer 1: Page component](#layer-1-page-component)
+- [Layer 2: Dynamic component](#layer-2-dynamic-component)
+- [Layer 3: Cached component](#layer-3-cached-component)
+- [`searchParams` and other dynamic APIs](#searchparams-and-other-dynamic-apis)
+
+## Structure
+
+```text
+Page/Layout (Layer 1)
+  ├── NOT draft mode → <CachedX perspective="published" stega={false} />  (no Suspense)
+  └── draft mode → <Suspense fallback={...}>
+                      <DynamicX params={params} />  (Layer 2)
+                        └── <CachedX params={await params} perspective={p} stega={s} />  (Layer 3)
+```
+
+## `generateStaticParams` for dynamic routes
+
+The examples below use `/[slug]/page.tsx`, which needs:
+
+```tsx
+// src/app/[slug]/page.tsx
+import {sanityFetchStaticParams} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+
+export async function generateStaticParams() {
+  const pageSlugsQuery = defineQuery(
+    `*[_type == "page" && defined(slug.current)]{"slug": slug.current}`,
+  )
+  const {data} = await sanityFetchStaticParams({query: pageSlugsQuery})
+  return data
+}
+```
+
+For `/layout.tsx` or `/page.tsx` (no params), skip the `params` handling.
+
+## Layer 1: Page component
+
+Calls `draftMode()` and branches:
+
+```tsx
+// src/app/[slug]/page.tsx (continued)
+import {draftMode} from 'next/headers'
+import {Suspense} from 'react'
+
+export default async function Page({params}: PageProps<'/[slug]'>) {
+  const {isEnabled: isDraftMode} = await draftMode()
+  if (isDraftMode) {
+    return (
+      <Suspense fallback={<PageFallback />}>
+        <DynamicPage
+          // do not await `params` here, it needs to be awaited in `<DynamicPage>` so the Suspense boundary works
+          params={params}
+        />
+      </Suspense>
+    )
+  }
+  const {slug} = await params
+  return <CachedPage slug={slug} perspective="published" stega={false} />
+}
+```
+
+Notes:
+
+- `Page` does **not** have a `'use cache'` directive. `draftMode()` is allowed inside `'use cache'`, but `Page` also `awaits` `params` (and may call `getDynamicFetchOptions()`, which reads `cookies()`), and those dynamic APIs are not allowed inside `'use cache'`. It's enough for `<CachedPage>` (Layer 3) to carry `'use cache'` for `Page` to be prerendered as part of the static shell.
+- Requires `generateStaticParams` if `params` is used as input to `sanityFetch`.
+- Not in draft mode → no `<Suspense>` boundary, maximizes the static shell.
+- In draft mode → `<DynamicPage />` inside `<Suspense>` will suspend twice:
+  1. when `<DynamicPage>` awaits `getDynamicFetchOptions()`
+  2. when `<CachedPage />` awaits `sanityFetch` with the resolved `perspective`/`stega`
+
+  A good fallback skeleton that doesn't cause layout shift is highly recommended.
+
+## Layer 2: Dynamic component
+
+Resolves `params`, `cookies()`, and `headers()` outside the cache boundary and passes plain props in:
+
+```tsx
+// src/app/[slug]/page.tsx (continued)
+import {getDynamicFetchOptions} from '@/sanity/lib/live'
+
+async function DynamicPage({params}: Pick<PageProps<'/[slug]'>, 'params'>) {
+  const [{slug}, {perspective, stega}] = await Promise.all([params, getDynamicFetchOptions()])
+
+  return <CachedPage slug={slug} perspective={perspective} stega={stega} />
+}
+```
+
+`draftMode()` is the only dynamic API allowed inside `'use cache'`, but in this pattern it isn't needed in Layer 3 because `perspective` and `stega` already encode the draft state.
+
+## Layer 3: Cached component
+
+Has `'use cache'` and only receives plain, serializable props:
+
+```tsx
+// src/app/[slug]/page.tsx (continued)
+import {sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+
+async function CachedPage({
+  slug,
+  perspective,
+  stega,
+}: Awaited<PageProps<'/[slug]'>['params']> & DynamicFetchOptions) {
+  'use cache'
+  const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
+  const {data} = await sanityFetch({
+    query: pageQuery,
+    params: {slug},
+    perspective,
+    stega,
+  })
+  return <article>{/* use `data` to render stuff */}</article>
+}
+```
+
+## `searchParams` and other dynamic APIs
+
+If `searchParams` or other dynamic APIs are inputs to `sanityFetch` (or `params` is used without `generateStaticParams` or a `loading.tsx`), always render the `<Suspense>` tree and **stop branching on `draftMode`**. See [the streaming guide](https://nextjs.org/docs/app/guides/streaming#when-to-use-loadingjs-vs-suspense) for picking between `loading.tsx` and `<Suspense>`.
+
+```tsx
+// src/app/[slug]/page.tsx (continued)
+import {Suspense} from 'react'
+
+// Do not export an async function here, to avoid accidentally blocking render while awaiting a dynamic API
+export default function Page({params}: PageProps<'/[slug]'>) {
+  return (
+    <Suspense
+      // not optional — no draftMode branch means a missing skeleton causes massive layout shift
+      fallback={<PageFallback />}
+    >
+      <DynamicPage
+        // do not await `params` here, it needs to be awaited in `<DynamicPage>` so the Suspense boundary works
+        params={params}
+      />
+    </Suspense>
+  )
+}
+```

--- a/app/(website)/[slug]/loading.tsx
+++ b/app/(website)/[slug]/loading.tsx
@@ -1,0 +1,12 @@
+export default function Loading() {
+  return (
+    <div className="w-5/6 space-y-4 lg:w-3/5">
+      <div className="h-10 w-3/4 animate-pulse rounded bg-gray-100 md:h-14" />
+      <div className="mt-4 space-y-2">
+        <div className="h-5 w-full animate-pulse rounded bg-gray-100" />
+        <div className="h-5 w-5/6 animate-pulse rounded bg-gray-100" />
+        <div className="h-5 w-2/3 animate-pulse rounded bg-gray-100" />
+      </div>
+    </div>
+  )
+}

--- a/app/(website)/[slug]/page.tsx
+++ b/app/(website)/[slug]/page.tsx
@@ -1,18 +1,21 @@
 import {CustomPortableText} from '@/components/CustomPortableText'
 import {Header} from '@/components/Header'
-import {sanityFetch} from '@/sanity/lib/live'
-import {slugsByTypeQuery, type SlugsByTypeQueryParams} from '@/sanity/lib/queries'
+import {
+  getDynamicFetchOptions,
+  sanityFetch,
+  sanityFetchMetadata,
+  sanityFetchStaticParams,
+  type DynamicFetchOptions,
+} from '@/sanity/lib/live'
 import type {Metadata, ResolvingMetadata} from 'next'
 import {defineQuery} from 'next-sanity'
 import {notFound} from 'next/navigation'
 
 export async function generateStaticParams() {
-  const {data} = await sanityFetch({
-    query: slugsByTypeQuery,
-    params: {type: 'page'} satisfies SlugsByTypeQueryParams,
-    perspective: 'published',
-    stega: false,
-  })
+  const pageSlugsQuery = defineQuery(
+    `*[_type == "page" && defined(slug.current)] | order(_updatedAt desc) [0...100]{"slug": slug.current}`,
+  )
+  const {data} = await sanityFetchStaticParams({query: pageSlugsQuery})
   return data
 }
 
@@ -20,17 +23,17 @@ export async function generateMetadata(
   {params}: PageProps<'/[slug]'>,
   parent: ResolvingMetadata,
 ): Promise<Metadata> {
-  const {slug} = await params
+  const [{slug}, {perspective}] = await Promise.all([params, getDynamicFetchOptions()])
   const slugPageMetadataQuery = defineQuery(`
     *[_type == "page" && slug.current == $slug][0] {
       title,
       "overview": pt::text(overview),
     }
   `)
-  const {data} = await sanityFetch({
+  const {data} = await sanityFetchMetadata({
     query: slugPageMetadataQuery,
     params: {slug},
-    stega: false,
+    perspective,
   })
 
   return {
@@ -40,7 +43,16 @@ export async function generateMetadata(
 }
 
 export default async function SlugPage({params}: PageProps<'/[slug]'>) {
-  const {slug} = await params
+  const [{slug}, {perspective, stega}] = await Promise.all([params, getDynamicFetchOptions()])
+  return <CachedSlugPage slug={slug} perspective={perspective} stega={stega} />
+}
+
+async function CachedSlugPage({
+  slug,
+  perspective,
+  stega,
+}: Awaited<PageProps<'/[slug]'>['params']> & DynamicFetchOptions) {
+  'use cache'
   const slugPageQuery = defineQuery(`
     *[_type == "page" && slug.current == $slug][0] {
       _id,
@@ -51,7 +63,7 @@ export default async function SlugPage({params}: PageProps<'/[slug]'>) {
       "slug": slug.current,
     }
   `)
-  const {data} = await sanityFetch({query: slugPageQuery, params: {slug}})
+  const {data} = await sanityFetch({query: slugPageQuery, params: {slug}, perspective, stega})
 
   if (!data?._id) notFound()
 

--- a/app/(website)/layout.tsx
+++ b/app/(website)/layout.tsx
@@ -2,7 +2,13 @@ import '@/styles/index.css'
 import {CustomPortableText} from '@/components/CustomPortableText'
 import {Navbar} from '@/components/Navbar'
 import IntroTemplate from '@/intro-template'
-import {sanityFetch, SanityLive} from '@/sanity/lib/live'
+import {
+  getDynamicFetchOptions,
+  sanityFetch,
+  sanityFetchMetadata,
+  SanityLive,
+  type DynamicFetchOptions,
+} from '@/sanity/lib/live'
 import {settingsQuery} from '@/sanity/lib/queries'
 import {urlForOpenGraphImage} from '@/sanity/lib/utils'
 import {SpeedInsights} from '@vercel/speed-insights/next'
@@ -23,9 +29,9 @@ export async function generateMetadata(): Promise<Metadata> {
       "overview": pt::text(overview),
     }
   }`)
-  const {
-    data: {settings, home},
-  } = await sanityFetch({query: layoutMetadataQuery, stega: false})
+  const {perspective} = await getDynamicFetchOptions()
+  const {data} = await sanityFetchMetadata({query: layoutMetadataQuery, perspective})
+  const {settings, home} = data ?? {}
 
   const ogImage = urlForOpenGraphImage(settings?.ogImage)
   return {
@@ -39,31 +45,70 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export const viewport: Viewport = {themeColor: '#000'}
 
+async function fetchSettings({perspective, stega}: DynamicFetchOptions) {
+  'use cache'
+  const {data} = await sanityFetch({query: settingsQuery, perspective, stega})
+  return data
+}
+
+async function DynamicNavbar() {
+  const {perspective, stega} = await getDynamicFetchOptions()
+  return <CachedNavbar perspective={perspective} stega={stega} />
+}
+async function CachedNavbar({perspective, stega}: DynamicFetchOptions) {
+  'use cache'
+  const data = await fetchSettings({perspective, stega})
+  return <Navbar data={data} />
+}
+
+async function DynamicFooter() {
+  const {perspective, stega} = await getDynamicFetchOptions()
+  return <CachedFooter perspective={perspective} stega={stega} />
+}
+async function CachedFooter({perspective, stega}: DynamicFetchOptions) {
+  'use cache'
+  const data = await fetchSettings({perspective, stega})
+  if (!Array.isArray(data?.footer)) return null
+  return (
+    <footer className="bottom-0 w-full bg-white py-12 text-center md:py-20">
+      <CustomPortableText
+        id={data._id}
+        type={data._type}
+        path={['footer']}
+        paragraphClasses="text-md md:text-xl"
+        value={data.footer}
+      />
+    </footer>
+  )
+}
+
 export default async function PersonalLayout({children}: LayoutProps<'/'>) {
-  const {data} = await sanityFetch({query: settingsQuery})
+  const {isEnabled: isDraftMode} = await draftMode()
   return (
     <>
       <div className="flex min-h-screen flex-col bg-white text-black">
-        <Navbar data={data} />
+        {isDraftMode ? (
+          <Suspense fallback={<Navbar data={null} />}>
+            <DynamicNavbar />
+          </Suspense>
+        ) : (
+          <CachedNavbar perspective="published" stega={false} />
+        )}
         <div className="mt-20 flex-grow px-4 md:px-16 lg:px-32">{children}</div>
-        {Array.isArray(data?.footer) && (
-          <footer className="bottom-0 w-full bg-white py-12 text-center md:py-20">
-            <CustomPortableText
-              id={data._id}
-              type={data._type}
-              path={['footer']}
-              paragraphClasses="text-md md:text-xl"
-              value={data.footer}
-            />
-          </footer>
+        {isDraftMode ? (
+          <Suspense>
+            <DynamicFooter />
+          </Suspense>
+        ) : (
+          <CachedFooter perspective="published" stega={false} />
         )}
         <Suspense>
           <IntroTemplate />
         </Suspense>
       </div>
       <Toaster />
-      <SanityLive onError={handleError} />
-      {(await draftMode()).isEnabled && (
+      <SanityLive includeDrafts={isDraftMode} onError={handleError} />
+      {isDraftMode && (
         <>
           <DraftModeToast
             action={async () => {

--- a/app/(website)/page.tsx
+++ b/app/(website)/page.tsx
@@ -3,12 +3,36 @@ import {Header} from '@/components/Header'
 import ImageBox from '@/components/ImageBox'
 import {OptimisticSortOrder} from '@/components/OptimisticSortOrder'
 import {studioUrl} from '@/sanity/lib/api'
-import {sanityFetch} from '@/sanity/lib/live'
+import {
+  getDynamicFetchOptions,
+  sanityFetch,
+  type DynamicFetchOptions,
+} from '@/sanity/lib/live'
 import {resolveHref} from '@/sanity/lib/utils'
 import {createDataAttribute, defineQuery} from 'next-sanity'
+import {draftMode} from 'next/headers'
 import Link from 'next/link'
+import {Suspense} from 'react'
 
 export default async function IndexPage() {
+  const {isEnabled: isDraftMode} = await draftMode()
+  if (isDraftMode) {
+    return (
+      <Suspense fallback={<HomePageFallback />}>
+        <DynamicHomePage />
+      </Suspense>
+    )
+  }
+  return <CachedHomePage perspective="published" stega={false} />
+}
+
+async function DynamicHomePage() {
+  const {perspective, stega} = await getDynamicFetchOptions()
+  return <CachedHomePage perspective={perspective} stega={stega} />
+}
+
+async function CachedHomePage({perspective, stega}: DynamicFetchOptions) {
+  'use cache'
   const homePageQuery = defineQuery(`
     *[_type == "home"][0]{
       _id,
@@ -29,7 +53,7 @@ export default async function IndexPage() {
       title,
     }
   `)
-  const {data} = await sanityFetch({query: homePageQuery})
+  const {data} = await sanityFetch({query: homePageQuery, perspective, stega})
 
   if (!data) {
     return (
@@ -125,6 +149,20 @@ export default async function IndexPage() {
               )
             })}
         </OptimisticSortOrder>
+      </div>
+    </div>
+  )
+}
+
+function HomePageFallback() {
+  return (
+    <div className="space-y-20">
+      <div className="mx-auto max-w-3xl space-y-4 py-10 text-center">
+        <div className="mx-auto h-10 w-1/2 animate-pulse rounded bg-gray-100" />
+        <div className="mx-auto h-4 w-3/4 animate-pulse rounded bg-gray-100" />
+      </div>
+      <div className="mx-auto max-w-[100rem] rounded-md border">
+        <div className="aspect-[16/9] w-full animate-pulse bg-gray-100" />
       </div>
     </div>
   )

--- a/app/(website)/projects/[slug]/loading.tsx
+++ b/app/(website)/projects/[slug]/loading.tsx
@@ -1,0 +1,16 @@
+export default function Loading() {
+  return (
+    <>
+      <div className="w-5/6 space-y-4 lg:w-3/5">
+        <div className="h-10 w-3/4 animate-pulse rounded bg-gray-100 md:h-14" />
+        <div className="mt-4 space-y-2">
+          <div className="h-5 w-full animate-pulse rounded bg-gray-100" />
+          <div className="h-5 w-5/6 animate-pulse rounded bg-gray-100" />
+        </div>
+      </div>
+      <div className="rounded-md border">
+        <div className="relative aspect-[16/9] w-full animate-pulse bg-gray-100" />
+      </div>
+    </>
+  )
+}

--- a/app/(website)/projects/[slug]/page.tsx
+++ b/app/(website)/projects/[slug]/page.tsx
@@ -2,8 +2,13 @@ import {CustomPortableText} from '@/components/CustomPortableText'
 import {Header} from '@/components/Header'
 import ImageBox from '@/components/ImageBox'
 import {studioUrl} from '@/sanity/lib/api'
-import {sanityFetch} from '@/sanity/lib/live'
-import {slugsByTypeQuery, type SlugsByTypeQueryParams} from '@/sanity/lib/queries'
+import {
+  getDynamicFetchOptions,
+  sanityFetch,
+  sanityFetchMetadata,
+  sanityFetchStaticParams,
+  type DynamicFetchOptions,
+} from '@/sanity/lib/live'
 import {urlForOpenGraphImage} from '@/sanity/lib/utils'
 import type {Metadata, ResolvingMetadata} from 'next'
 import {createDataAttribute, defineQuery} from 'next-sanity'
@@ -11,12 +16,10 @@ import Link from 'next/link'
 import {notFound} from 'next/navigation'
 
 export async function generateStaticParams() {
-  const {data} = await sanityFetch({
-    query: slugsByTypeQuery,
-    params: {type: 'project'} satisfies SlugsByTypeQueryParams,
-    stega: false,
-    perspective: 'published',
-  })
+  const projectSlugsQuery = defineQuery(
+    `*[_type == "project" && defined(slug.current)] | order(_updatedAt desc) [0...100]{"slug": slug.current}`,
+  )
+  const {data} = await sanityFetchStaticParams({query: projectSlugsQuery})
   return data
 }
 
@@ -24,7 +27,7 @@ export async function generateMetadata(
   {params}: PageProps<'/projects/[slug]'>,
   parent: ResolvingMetadata,
 ): Promise<Metadata> {
-  const {slug} = await params
+  const [{slug}, {perspective}] = await Promise.all([params, getDynamicFetchOptions()])
   const projectSlugPageMetadataQuery = defineQuery(`
     *[_type == "project" && slug.current == $slug][0] {
       coverImage,
@@ -32,10 +35,10 @@ export async function generateMetadata(
       "overview": pt::text(overview),
     }
   `)
-  const {data} = await sanityFetch({
+  const {data} = await sanityFetchMetadata({
     query: projectSlugPageMetadataQuery,
     params: {slug},
-    stega: false,
+    perspective,
   })
 
   const ogImage = urlForOpenGraphImage(data?.coverImage)
@@ -47,7 +50,16 @@ export async function generateMetadata(
 }
 
 export default async function ProjectSlugPage({params}: PageProps<'/projects/[slug]'>) {
-  const {slug} = await params
+  const [{slug}, {perspective, stega}] = await Promise.all([params, getDynamicFetchOptions()])
+  return <CachedProjectSlugPage slug={slug} perspective={perspective} stega={stega} />
+}
+
+async function CachedProjectSlugPage({
+  slug,
+  perspective,
+  stega,
+}: Awaited<PageProps<'/projects/[slug]'>['params']> & DynamicFetchOptions) {
+  'use cache'
   const projectSlugPageQuery = defineQuery(`
     *[_type == "project" && slug.current == $slug][0] {
       _id,
@@ -63,7 +75,12 @@ export default async function ProjectSlugPage({params}: PageProps<'/projects/[sl
       title,
     }
   `)
-  const {data} = await sanityFetch({query: projectSlugPageQuery, params: {slug}})
+  const {data} = await sanityFetch({
+    query: projectSlugPageQuery,
+    params: {slug},
+    perspective,
+    stega,
+  })
 
   if (!data?._id) notFound()
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
 import {NextConfig} from 'next'
+import {sanity} from 'next-sanity/live/cache-life'
 
 const config: NextConfig = {
+  cacheComponents: true,
+  cacheLife: {default: sanity},
   reactCompiler: true,
   images: {
     remotePatterns: [{hostname: 'cdn.sanity.io'}],

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "classnames": "2.5.1",
         "date-fns": "4.1.0",
         "next": "16.2.6",
-        "next-sanity": "12.4.5",
+        "next-sanity": "13.0.0-cache-components.62",
         "react": "19.2.6",
         "react-dom": "19.2.6",
         "react-live-transitions": "0.2.0",
@@ -12347,20 +12347,18 @@
       }
     },
     "node_modules/next-sanity": {
-      "version": "12.4.5",
-      "resolved": "https://registry.npmjs.org/next-sanity/-/next-sanity-12.4.5.tgz",
-      "integrity": "sha512-KXqUOfxk8FsVOzKbISRcYCqMxGbUbWO7spYjRHQxv9KyFbYH3ofMHeAvj5uojZ1it+/y2nKFcUk9s4EUOWVwbA==",
+      "version": "13.0.0-cache-components.62",
+      "resolved": "https://registry.npmjs.org/next-sanity/-/next-sanity-13.0.0-cache-components.62.tgz",
+      "integrity": "sha512-QE3xZyihGlYF/+1vlQQR0YAnBTbwH2W4fTwKHkDXVRBmfnjczqllYKTRZqmxgD5Wmdv6MxUE8BvOx8/00PMPiw==",
       "license": "MIT",
       "dependencies": {
         "@portabletext/react": "^6.2.0",
         "@sanity/client": "^7.22.0",
-        "@sanity/comlink": "^4.0.1",
-        "@sanity/presentation-comlink": "^2.0.1",
+        "@sanity/generate-help-url": "^4.0.0",
         "@sanity/preview-url-secret": "^4.0.6",
-        "@sanity/visual-editing": "^5.3.4",
+        "@sanity/visual-editing": "^5.3.6",
         "@sanity/webhook": "^4.0.4",
-        "dequal": "^2.0.3",
-        "groq": "^5.24.0",
+        "groq": "^5.25.1",
         "history": "^5.3.0"
       },
       "engines": {
@@ -12371,7 +12369,7 @@
         "next": "^16.0.0-0",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
-        "sanity": "^5.24.0",
+        "sanity": "^5.25.1",
         "styled-components": "^6.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "classnames": "2.5.1",
     "date-fns": "4.1.0",
     "next": "16.2.6",
-    "next-sanity": "12.4.5",
+    "next-sanity": "13.0.0-cache-components.62",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "react-live-transitions": "0.2.0",

--- a/sanity.types.ts
+++ b/sanity.types.ts
@@ -422,6 +422,13 @@ export type AllSanitySchemaTypes =
   | Geopoint
 
 // Source: app/(website)/[slug]/page.tsx
+// Variable: pageSlugsQuery
+// Query: *[_type == "page" && defined(slug.current)] | order(_updatedAt desc) [0...100]{"slug": slug.current}
+export type PageSlugsQueryResult = Array<{
+  slug: string | null
+}>
+
+// Source: app/(website)/[slug]/page.tsx
 // Variable: slugPageMetadataQuery
 // Query: *[_type == "page" && slug.current == $slug][0] {      title,      "overview": pt::text(overview),    }
 export type SlugPageMetadataQueryResult = {
@@ -560,6 +567,13 @@ export type HomePageQueryResult = {
   }> | null
   title: string | null
 } | null
+
+// Source: app/(website)/projects/[slug]/page.tsx
+// Variable: projectSlugsQuery
+// Query: *[_type == "project" && defined(slug.current)] | order(_updatedAt desc) [0...100]{"slug": slug.current}
+export type ProjectSlugsQueryResult = Array<{
+  slug: string | null
+}>
 
 // Source: app/(website)/projects/[slug]/page.tsx
 // Variable: projectSlugPageMetadataQuery
@@ -706,10 +720,12 @@ export type SlugsByTypeQueryResult = Array<{
 
 declare module '@sanity/client' {
   interface SanityQueries {
+    '*[_type == "page" && defined(slug.current)] | order(_updatedAt desc) [0...100]{"slug": slug.current}': PageSlugsQueryResult
     '\n    *[_type == "page" && slug.current == $slug][0] {\n      title,\n      "overview": pt::text(overview),\n    }\n  ': SlugPageMetadataQueryResult
     '\n    *[_type == "page" && slug.current == $slug][0] {\n      _id,\n      _type,\n      body,\n      overview,\n      title,\n      "slug": slug.current,\n    }\n  ': SlugPageQueryResult
     '{\n    "settings": *[_type == "settings"][0]{ogImage},\n    "home": *[_type == "home"][0]{\n      title,\n      "overview": pt::text(overview),\n    }\n  }': LayoutMetadataQueryResult
     '\n    *[_type == "home"][0]{\n      _id,\n      _type,\n      overview,\n      showcaseProjects[]{\n        _key,\n        ...@->{\n          _id,\n          _type,\n          coverImage,\n          overview,\n          "slug": slug.current,\n          tags,\n          title,\n        }\n      },\n      title,\n    }\n  ': HomePageQueryResult
+    '*[_type == "project" && defined(slug.current)] | order(_updatedAt desc) [0...100]{"slug": slug.current}': ProjectSlugsQueryResult
     '\n    *[_type == "project" && slug.current == $slug][0] {\n      coverImage,\n      title,\n      "overview": pt::text(overview),\n    }\n  ': ProjectSlugPageMetadataQueryResult
     '\n    *[_type == "project" && slug.current == $slug][0] {\n      _id,\n      _type,\n      client,\n      coverImage,\n      description,\n      duration,\n      overview,\n      site,\n      "slug": slug.current,\n      tags,\n      title,\n    }\n  ': ProjectSlugPageQueryResult
     '\n  *[_type == "settings"][0]{\n    _id,\n    _type,\n    footer,\n    menuItems[]{\n      _key,\n      ...@->{\n        _type,\n        "slug": slug.current,\n        title\n      }\n    },\n    ogImage,\n  }\n': SettingsQueryResult

--- a/sanity/lib/live.ts
+++ b/sanity/lib/live.ts
@@ -1,4 +1,6 @@
-import {defineLive} from 'next-sanity/live'
+import {type QueryParams} from 'next-sanity'
+import {defineLive, resolvePerspectiveFromCookies, type LivePerspective} from 'next-sanity/live'
+import {cookies, draftMode} from 'next/headers'
 import {client} from './client'
 import {token} from './token'
 
@@ -6,4 +8,49 @@ export const {SanityLive, sanityFetch} = defineLive({
   client,
   serverToken: token,
   browserToken: token,
+  strict: true,
 })
+
+export interface DynamicFetchOptions {
+  perspective: LivePerspective
+  stega: boolean
+}
+
+export async function getDynamicFetchOptions(): Promise<DynamicFetchOptions> {
+  const {isEnabled: isDraftMode} = await draftMode()
+  if (!isDraftMode) {
+    return {perspective: 'published', stega: false}
+  }
+
+  const jar = await cookies()
+  const perspective = await resolvePerspectiveFromCookies({cookies: jar})
+  return {perspective: perspective ?? 'drafts', stega: true}
+}
+
+// For usage within `generateStaticParams`
+export async function sanityFetchStaticParams<const QueryString extends string>({
+  query,
+  params = {},
+}: {
+  query: QueryString
+  params?: QueryParams
+}) {
+  'use cache'
+  const {data} = await sanityFetch({query, params, perspective: 'published', stega: false})
+  return {data}
+}
+
+// For usage within `generateMetadata` and `generateViewport`
+export async function sanityFetchMetadata<const QueryString extends string>({
+  query,
+  params = {},
+  perspective,
+}: {
+  query: QueryString
+  params?: QueryParams
+  perspective: LivePerspective
+}) {
+  'use cache'
+  const {data} = await sanityFetch({query, params, perspective, stega: false})
+  return {data}
+}

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "sanity-live-cache-components": {
+      "source": "sanity-io/next-sanity",
+      "sourceType": "github",
+      "skillPath": "skills/sanity-live-cache-components/SKILL.md",
+      "computedHash": "846b54cd473b7542daf5d1194bf428f7798b02336b9401dd7206fc32fefda4a0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR is a **skill eval** of [`sanity-io/next-sanity#3581`](https://github.com/sanity-io/next-sanity/pull/3581) (the docs(skill) restructure for `sanity-live-cache-components`).

Workflow followed exactly as the changeset in [`.changeset/slimy-cougars-sing.md`](https://github.com/sanity-io/next-sanity/blob/4c516d49138a3bcf096c1662162eb80c13fa5f41/.changeset/slimy-cougars-sing.md) prescribes:

1. `npx skills add https://github.com/sanity-io/next-sanity --skill sanity-live-cache-components` (installed to `.agents/skills/sanity-live-cache-components/`).
2. Overwrote the installed `SKILL.md` and added the 4 `reference/*.md` files from PR #3581 commit [`936ae55`](https://github.com/sanity-io/next-sanity/commit/936ae5583f1ba1401c155688d20e6dc5a2d46dad) so the migration would be driven by the rewritten skill, not the current `main` version. The five overwritten files are committed under `.agents/skills/sanity-live-cache-components/` for full traceability.
3. Drove the migration using only those skill files plus their links, exactly as the changeset's suggested prompt asks.

The migration itself is the eval — judging how the rewritten skill performs is the point.

## What changed in the template

- **`next-sanity@13`** via the `cache-components` dist-tag (`13.0.0-cache-components.62` — `latest` is still 12.4.5).
- **`next.config.ts`**: enable `cacheComponents: true` and set `cacheLife: {default: sanity}` from `next-sanity/live/cache-life`.
- **`sanity/lib/live.ts`**: add `strict: true`, plus `getDynamicFetchOptions`, `sanityFetchStaticParams`, `sanityFetchMetadata`, and the `DynamicFetchOptions` type per `reference/live-helpers.md`. Kept the existing `import {token} from './token'` (which carries `import 'server-only'`) instead of inlining `process.env.SANITY_API_READ_TOKEN` as the skill's example does.
- **`app/(website)/layout.tsx`**: applied the `reference/layouts.md` "shared `'use cache'` helper per draft/published branch" pattern. Extracted `fetchSettings({perspective, stega})` and split Navbar/Footer into `DynamicX`/`CachedX` pairs. Wired `includeDrafts={isDraftMode}` on `<SanityLive>` (required under `strict: true`). Swapped the `generateMetadata` `sanityFetch` for `sanityFetchMetadata`.
- **`app/(website)/page.tsx`**: applied the Page/Dynamic/Cached three-layer pattern from `reference/three-layer-pattern.md` (no `params` here, so the layer-1 branch is just the `draftMode()` check, fallback skeleton inline).
- **`app/(website)/[slug]/page.tsx`** and **`app/(website)/projects/[slug]/page.tsx`**: applied `reference/dynamic-segments.md` **Case 1** (sibling `loading.tsx` + partial `generateStaticParams`). `generateStaticParams` → `sanityFetchStaticParams` with `| order(_updatedAt desc) [0...100]`. `generateMetadata` → `sanityFetchMetadata`. Sibling `loading.tsx` added in both directories.
- **`sanity/lib/client.ts`**: left unchanged. The base-client `perspective: 'published'` and `stega.*` defaults are intentional; the skill's anti-pattern targets per-call hardcoding inside `sanityFetch`, not the base client. (Verified explicitly with the skill's author.)

## Verification

- `npm run type-check`, `npm run lint`, `npm run build` all green locally with the project's real Sanity env vars.
- `next build` prerenders the static shell with `Revalidate 1y` on `/`, `/[slug]`, `/projects/[slug]`. Dynamic segments show as Partial Prerender (◐), exactly what `reference/dynamic-segments.md` predicts with the partial-`generateStaticParams` + `loading.tsx` setup.
- `next dev` smoke test: home, `/about`, `/projects/project-b`, `/studio` all return 200 with real Sanity content (titles populated from the dataset). `<SanityLive>` mounts. `/api/draft-mode/enable` correctly 401s without a valid Presentation-Tool-signed secret.
- **Draft mode on/off** still needs to be exercised through Presentation Tool, which is the whole point of opening this as a draft PR — see "How to test" below.

## How to test (humans, please)

The Vercel preview will attach as a bot comment.

1. **Draft mode off** (default browse): open the preview, walk the home → a `[slug]` page → a `projects/[slug]` page. Pages should render from the static shell instantly; `<SanityLive>` should connect over EventSource.
2. **Draft mode on**: open Presentation Tool against the preview URL, mint a draft-mode secret, and verify Visual Editing overlays render and the navbar/footer/page content stream in under their Suspense fallbacks. Test against both perspectives and a Content Release.
3. Verify there's still exactly one `<SanityLive>` and one `<VisualEditing>` in the tree (both should live in `app/(website)/layout.tsx`).

This is intentionally a draft PR — the Vercel preview is the integration test, not anything to merge.

## Eval findings for `stipsan`

Posted as a follow-up comment on this PR.


Made with [Cursor](https://cursor.com)