### PR TITLE
Migrate to Next.js Cache Components

### DIFF
--- a/.agents/skills/sanity-live-cache-components/SKILL.md
+++ b/.agents/skills/sanity-live-cache-components/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: sanity-live-cache-components
+description: Integrates Sanity Live with Next.js Cache Components in next-sanity v13+ apps. Sets up sanityFetch, <SanityLive>, Visual Editing, Presentation Tool, draft mode handling, and the three-layer (Page/Dynamic/Cached) component pattern with explicit perspective/stega prop-drilling. Use when configuring or migrating a Next.js app to cacheComponents with Sanity, when adding sanityFetch, when wiring <SanityLive>/<VisualEditing>, or when refactoring components that hardcode perspective/stega.
+---
+
+# Sanity Live + Cache Components
+
+Wires `next-sanity` into a Next.js 16+ app with `cacheComponents: true`. Data is fetched with `sanityFetch` (which calls `cacheTag`/`cacheLife` internally), and `<SanityLive>` in the root layout revalidates cached content over an EventSource connection to Sanity Content Lake. Visual Editing and Presentation Tool are fully supported when draft mode is enabled.
+
+Read the relevant guide in `node_modules/next/dist/docs/` (when available) before writing code. If a guide conflicts with this skill, follow this skill.
+
+This skill assumes familiarity with the `next-cache-components` skill — it covers `'use cache'`, `cacheLife`, `cacheTag`, and the cookies/headers/params rule. The only Sanity-relevant exception: `await draftMode()` is allowed inside `'use cache'` (Next.js bypasses caching when draft mode is enabled — see [the `use cache` reference](https://nextjs.org/docs/app/api-reference/directives/use-cache#draft-mode)).
+
+## Prerequisites
+
+- Next.js 16.2+ installed in the project (check `package.json` or run `pnpm list next` / `npm ls next` — don't use `pnpm view next version`, that reports the registry's latest, not what's installed).
+- `AGENTS.md` exists, or [follow the guide](https://nextjs.org/docs/app/guides/ai-agents#existing-projects).
+- These environment variables are set:
+  - `NEXT_PUBLIC_SANITY_PROJECT_ID`
+  - `NEXT_PUBLIC_SANITY_DATASET`
+  - `SANITY_API_READ_TOKEN`
+- Embedded Sanity Studio configuration (`sanity.config.ts`, `sanity.cli.ts`, anything under `sanity/`) needs no changes — this skill only touches the Next.js app surface.
+
+## Reference files
+
+| File                                                                 | When to read                                                                                                                   |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| [reference/live-helpers.md](reference/live-helpers.md)               | Full `client.ts` / `live.ts`, `sanityFetch*` and `getDynamicFetchOptions` details                                              |
+| [reference/three-layer-pattern.md](reference/three-layer-pattern.md) | The Page → Dynamic → Cached pattern for `page.tsx`, including the `searchParams` variant                                       |
+| [reference/layouts.md](reference/layouts.md)                         | Non-blocking data fetching inside `layout.tsx` with a shared `'use cache'` helper                                              |
+| [reference/dynamic-segments.md](reference/dynamic-segments.md)       | High-performance `[slug]` routes: `loading.tsx` + partial `generateStaticParams`, or non-blocking dynamic `params` in a layout |
+
+---
+
+## 1. Install `next-sanity@^13`
+
+```bash
+npm install next-sanity@^13 --save-exact
+```
+
+### Migrating an existing Sanity Live setup
+
+If the app is already using `defineLive`, this skill is a refactor, not a rewrite. The 5-step sequence below still applies, but watch for these specific differences:
+
+- **Don't overwrite `client.ts` or `live.ts`** if they exist. Append missing options. Preserve any existing `token` and `stega.*` settings — see [reference/live-helpers.md](reference/live-helpers.md).
+- **Search the codebase for hardcoded `perspective: 'published'` and `stega: false`** in `sanityFetch` callsites and refactor them to source `perspective`/`stega` via `getDynamicFetchOptions` and the three-layer pattern.
+- **Search for `sanityFetch` calls inside `generateStaticParams`** → swap for `sanityFetchStaticParams`.
+- **Search for `sanityFetch` calls inside `generateMetadata` / `sitemap.ts` / `opengraph-image.tsx` / etc.** → swap for `sanityFetchMetadata`.
+- **Search for `sanityFetch` calls directly inside a `'use server'` function** → split into a separate `'use cache'` helper.
+- **Verify there is exactly one `<SanityLive>` and one `<VisualEditing>` in the tree.** Multiple renders are undefined behavior.
+
+The "Anti-patterns to grep for" section at the bottom of this file lists the search patterns.
+
+---
+
+## 2. Configure `next.config.ts`
+
+Enable `cacheComponents` and set `cacheLife.default` to `sanity` so default revalidation is 1 year (instead of 15 minutes). `sanityFetch` is optimized for on-demand revalidation and doesn't need time-based revalidation.
+
+```ts
+// next.config.ts
+import type {NextConfig} from 'next'
+import {sanity} from 'next-sanity/live/cache-life'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  cacheLife: {default: sanity},
+}
+
+export default nextConfig
+```
+
+---
+
+## 3. Configure `defineLive` and export helpers
+
+Create `src/sanity/lib/client.ts` and `src/sanity/lib/live.ts`. The minimal `defineLive` call:
+
+```ts
+// src/sanity/lib/live.ts (excerpt)
+export const {SanityLive, sanityFetch} = defineLive({
+  client,
+  serverToken: token,
+  browserToken: token,
+  strict: true,
+})
+```
+
+Full file contents (including `client.ts`, `getDynamicFetchOptions`, `sanityFetchMetadata`, `sanityFetchStaticParams`) and per-helper guidance: [reference/live-helpers.md](reference/live-helpers.md).
+
+The helpers exported from `live.ts`:
+
+| Helper                    | Used in                                                                                        |
+| ------------------------- | ---------------------------------------------------------------------------------------------- |
+| `sanityFetch`             | `'use cache'` components rendered from `page.tsx` / `layout.tsx`                               |
+| `sanityFetchMetadata`     | `generateMetadata`, `generateViewport`, `sitemap.ts`, `robots.ts`, `opengraph-image.tsx`, etc. |
+| `sanityFetchStaticParams` | `generateStaticParams` only                                                                    |
+| `getDynamicFetchOptions`  | Resolving `perspective`/`stega` outside any `'use cache'` boundary                             |
+| `SanityLive`              | Rendered once in a root layout                                                                 |
+
+---
+
+## 4. Render `<SanityLive>` in a root layout
+
+`<SanityLive>` and `<VisualEditing>` both belong in a `layout.tsx`, never a `page.tsx`. Both must be rendered at most once across the whole tree — duplicate renders are undefined behavior.
+
+- `includeDrafts` is **required** when `defineLive` is configured with `strict: true` (the recommended setup). TypeScript will surface the error if it's missing; pass `includeDrafts={isDraftMode}` so live revalidation includes drafts only in draft mode.
+- Preserve any existing optional callback props on `<SanityLive>` when migrating: `onError`, `onWelcome`, `onReconnect`. They are commonly wired to a toast/notification helper and silently dropping them regresses UX.
+
+```tsx
+// src/app/layout.tsx
+import {SanityLive} from '@/sanity/lib/live'
+import {VisualEditing} from 'next-sanity/visual-editing'
+import {draftMode} from 'next/headers'
+
+export default async function RootLayout({children}: LayoutProps<'/'>) {
+  const {isEnabled: isDraftMode} = await draftMode()
+  return (
+    <html lang="en">
+      <body>
+        {children}
+        <SanityLive includeDrafts={isDraftMode} />
+        {isDraftMode && <VisualEditing />}
+      </body>
+    </html>
+  )
+}
+```
+
+### With an embedded Sanity Studio
+
+If a route mounts `NextStudio` from `next-sanity/studio` (e.g. `app/studio/[[...index]]/page.tsx`), `<SanityLive>` must live in a layout the embedded studio doesn't share. Use [route groups](https://nextjs.org/docs/app/api-reference/file-conventions/route-groups): put `<SanityLive>` in `src/app/(website)/layout.tsx` and keep the rest of the app under `src/app/(website)`.
+
+---
+
+## 5. Apply the three-layer pattern to pages and layouts
+
+Every route that should be statically prerendered uses the same shape:
+
+```text
+Page/Layout (Layer 1: draftMode branch)
+  ├── NOT draft mode → <CachedX perspective="published" stega={false} />  (no Suspense)
+  └── draft mode → <Suspense fallback={...}>
+                      <DynamicX params={params} />  (Layer 2: awaits dynamic APIs)
+                        └── <CachedX perspective={p} stega={s} />  (Layer 3: 'use cache')
+```
+
+**Critical rule**: Only Layer 3 carries `'use cache'`. The top-level `Page` / `Layout` must **not** have `'use cache'` — it awaits `params`, `searchParams`, or `cookies()` (via `getDynamicFetchOptions`), and those dynamic APIs are forbidden inside `'use cache'`. Layer 3 carrying `'use cache'` is enough for the whole route to prerender into the static shell. Adding `'use cache'` to the top-level function is the most common failure mode — TypeScript and the runtime will both complain.
+
+Pick the right reference for the file you're editing:
+
+- **`page.tsx`** with static or `generateStaticParams`-backed params → [reference/three-layer-pattern.md](reference/three-layer-pattern.md).
+- **`page.tsx`** that uses `searchParams` or other dynamic APIs → the `searchParams` variant in [reference/three-layer-pattern.md](reference/three-layer-pattern.md).
+- **`layout.tsx`** that fetches its own data → [reference/layouts.md](reference/layouts.md).
+- **Dynamic `[slug]` route** that needs the `loading.tsx` + partial `generateStaticParams` optimization, or a layout that needs non-blocking `params` → [reference/dynamic-segments.md](reference/dynamic-segments.md).
+
+---
+
+## Anti-patterns to grep for
+
+When auditing an app, search for these and refactor:
+
+- `perspective: 'published'` and `stega: false` hardcoded together in a `sanityFetch` call → use the three-layer pattern, source `perspective`/`stega` via `getDynamicFetchOptions`.
+- `sanityFetch(` directly inside a function whose body begins with `'use server'` → split into a separate `'use cache'` helper.
+- `sanityFetch(` inside `generateStaticParams` → swap for `sanityFetchStaticParams`.
+- `sanityFetch(` inside `generateMetadata` / `generateViewport` / `sitemap.ts` / `robots.ts` / `opengraph-image.tsx` etc. → swap for `sanityFetchMetadata` and resolve `perspective` via `getDynamicFetchOptions`.
+- `await draftMode()` immediately followed by `await getDynamicFetchOptions()` at the top of a `page.tsx` or `layout.tsx` without a sibling `loading.tsx` → move those dynamic-API calls into a child component wrapped in `<Suspense>` so the static shell can prerender.
+- More than one `<SanityLive>` or `<VisualEditing>` rendered in the tree → consolidate to a single render in the right layout.

--- a/.agents/skills/sanity-live-cache-components/reference/dynamic-segments.md
+++ b/.agents/skills/sanity-live-cache-components/reference/dynamic-segments.md
@@ -1,0 +1,114 @@
+# High-performance dynamic segments
+
+[Dynamic routes](https://nextjs.org/docs/app/api-reference/file-conventions/dynamic-routes) should always implement `generateStaticParams`, even if only a subset of pages — see [the Cache Components note on dynamic routes](https://nextjs.org/docs/app/api-reference/file-conventions/dynamic-routes#with-cache-components). Whether to use `loading.tsx` or `<Suspense>` for fallback UI depends on the use case — see [the streaming guide](https://nextjs.org/docs/app/guides/streaming#when-to-use-loadingjs-vs-suspense).
+
+## Contents
+
+- [Case 1: `page.tsx` with `loading.tsx` + partial `generateStaticParams`](#case-1-pagetsx-with-loadingtsx--partial-generatestaticparams)
+- [Case 2: `layout.tsx` with non-blocking dynamic `params`](#case-2-layouttsx-with-non-blocking-dynamic-params)
+
+## Case 1: `page.tsx` with `loading.tsx` + partial `generateStaticParams`
+
+`generateStaticParams` returns only the 100 most recently updated pages. A sibling `loading.tsx` renders fallback UI, so `page.tsx` itself can skip the `<Suspense>` wrapper. The same fallback UI is reused in draft mode.
+
+This scales to thousands of pages without ballooning `next build` and without compromising UX in production:
+
+- Prerendered pages load instantly.
+- Pages not prerendered start rendering on `<Link>` hover (or when scrolled into view), so on click:
+  - If prerendering finished in time → serves instantly, no loading state.
+  - If not → instantly shows the cached `loading.tsx` fallback.
+
+Add a sibling `src/app/[slug]/loading.tsx` that renders the same skeleton you would otherwise pass to `<Suspense>`. Keep it cheap and free of layout shift:
+
+```tsx
+// src/app/[slug]/loading.tsx
+export default function Loading() {
+  return (
+    <article aria-busy>
+      <p>Loading…</p>
+    </article>
+  )
+}
+```
+
+```tsx
+// src/app/[slug]/page.tsx
+import {
+  getDynamicFetchOptions,
+  sanityFetch,
+  sanityFetchStaticParams,
+  type DynamicFetchOptions,
+} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+
+export async function generateStaticParams() {
+  const pageSlugsQuery = defineQuery(
+    `*[_type == "page" && defined(slug.current)] | order(_updatedAt desc) [0...100]{"slug": slug.current}`,
+  )
+  const {data} = await sanityFetchStaticParams({query: pageSlugsQuery})
+  return data
+}
+
+// With sibling `loading.tsx`, skip the `<Suspense>` + `DynamicPage` indirection: await `params`
+// and `getDynamicFetchOptions` directly inside `Page`.
+export default async function Page({params}: PageProps<'/[slug]'>) {
+  const [{slug}, {perspective, stega}] = await Promise.all([params, getDynamicFetchOptions()])
+  return <CachedPage slug={slug} perspective={perspective} stega={stega} />
+}
+async function CachedPage({
+  slug,
+  perspective,
+  stega,
+}: Awaited<PageProps<'/[slug]'>['params']> & DynamicFetchOptions) {
+  'use cache'
+  const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
+  const {data} = await sanityFetch({
+    query: pageQuery,
+    params: {slug},
+    perspective,
+    stega,
+  })
+  return <article>{/* use `data` to render stuff */}</article>
+}
+```
+
+## Case 2: `layout.tsx` with non-blocking dynamic `params`
+
+A `layout.tsx` can't use `loading.tsx` for fallback UI — [it's one level higher in the hierarchy](https://nextjs.org/docs/app/getting-started/project-structure#component-hierarchy). To fetch data that depends on dynamic `params` without blocking `children` from streaming, pass the unawaited `params` promise into a `<Suspense>` boundary and await it inside.
+
+```tsx
+// src/app/(website)/[slug]/layout.tsx
+
+import {getDynamicFetchOptions, sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+import {Suspense} from 'react'
+
+export default function WebsiteLayout({children, params}: LayoutProps<'/[slug]'>) {
+  return (
+    <>
+      {children}
+      {/* The footer renders below the fold, no fallback needed */}
+      <Suspense>
+        <DynamicFooter
+          // Don't await `params` here — pass the promise and await inside Suspense so `children` streams in parallel
+          params={params}
+        />
+      </Suspense>
+    </>
+  )
+}
+async function DynamicFooter({params}: Pick<LayoutProps<'/[slug]'>, 'params'>) {
+  const [{slug}, {perspective, stega}] = await Promise.all([params, getDynamicFetchOptions()])
+  return <Footer slug={slug} perspective={perspective} stega={stega} />
+}
+async function Footer({
+  slug,
+  perspective,
+  stega,
+}: Awaited<LayoutProps<'/[slug]'>['params']> & DynamicFetchOptions) {
+  'use cache'
+  const footerQuery = defineQuery(`*[_type == "footer" && slug.current == $slug][0]`)
+  const {data} = await sanityFetch({query: footerQuery, params: {slug}, perspective, stega})
+  return <footer>{/* use `data` to render stuff */}</footer>
+}
+```

--- a/.agents/skills/sanity-live-cache-components/reference/layouts.md
+++ b/.agents/skills/sanity-live-cache-components/reference/layouts.md
@@ -1,0 +1,163 @@
+# Non-blocking layout patterns
+
+When `sanityFetch` runs inside a `layout.tsx`, the goal is to keep `children` streaming and keep the static shell as large as possible.
+
+## Contents
+
+- [Rules](#rules)
+- [Pattern: shared `'use cache'` helper per draft/published branch](#pattern-shared-use-cache-helper-per-draftpublished-branch)
+- [Anti-pattern: wrapping `children` in a single cached layout](#anti-pattern-wrapping-children-in-a-single-cached-layout)
+- [Simpler example: a single `<Footer>`](#simpler-example-a-single-footer)
+
+## Rules
+
+- The top-level `layout.tsx` component must not `await` dynamic APIs (other than `draftMode()`) or fetch data. `draftMode()` is the lone exception because Next.js bypasses caching when it's enabled and a `draftMode()`-only top-level component still prerenders into the static shell. Anything else (`cookies()`, `headers()`, `await params`, `await searchParams`, `sanityFetch`) reduces the static shell or slows draft-mode streaming.
+- Push [dynamic API calls](https://nextjs.org/docs/app/guides/streaming#push-dynamic-access-down) down to the leaf that needs them.
+- Extract shared data fetching into a reusable async `'use cache'` helper so two components that need the same data don't both wait independently.
+
+## Pattern: shared `'use cache'` helper per draft/published branch
+
+```tsx
+// src/app/(website)/layout.tsx
+import {getDynamicFetchOptions, sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+import {draftMode} from 'next/headers'
+import {Suspense} from 'react'
+
+async function fetchSettings({perspective, stega}: DynamicFetchOptions) {
+  'use cache'
+  const settingsQuery = defineQuery(`*[_type == "settings"][0]`)
+  const {data} = await sanityFetch({query: settingsQuery, perspective, stega})
+  return data
+}
+
+export default async function WebsiteLayout({children}: LayoutProps<'/'>) {
+  const {isEnabled: isDraftMode} = await draftMode()
+  return (
+    <>
+      {isDraftMode ? (
+        <Suspense fallback={<NavbarFallback />}>
+          <DynamicNavbar />
+        </Suspense>
+      ) : (
+        <CachedNavbar perspective="published" stega={false} />
+      )}
+      {children}
+      {isDraftMode ? (
+        <Suspense>
+          <DynamicFooter />
+        </Suspense>
+      ) : (
+        <CachedFooter perspective="published" stega={false} />
+      )}
+    </>
+  )
+}
+
+async function DynamicNavbar() {
+  const {perspective, stega} = await getDynamicFetchOptions()
+  return <CachedNavbar perspective={perspective} stega={stega} />
+}
+async function CachedNavbar({perspective, stega}: DynamicFetchOptions) {
+  'use cache'
+  const data = await fetchSettings({perspective, stega})
+  return <Navbar data={data} />
+}
+
+async function DynamicFooter() {
+  const {perspective, stega} = await getDynamicFetchOptions()
+  return <CachedFooter perspective={perspective} stega={stega} />
+}
+async function CachedFooter({perspective, stega}: DynamicFetchOptions) {
+  'use cache'
+  const data = await fetchSettings({perspective, stega})
+  return <Footer data={data} />
+}
+```
+
+## Anti-pattern: wrapping `children` in a single cached layout
+
+This blocks `children` on the layout's data fetch and prevents the page itself from streaming in independently.
+
+```tsx
+// src/app/(website)/layout.tsx
+export default async function WebsiteLayout({children}: LayoutProps<'/'>) {
+  const {isEnabled: isDraftMode} = await draftMode()
+  if (isDraftMode) {
+    return (
+      <Suspense>
+        <DynamicWebsiteLayout>{children}</DynamicWebsiteLayout>
+      </Suspense>
+    )
+  }
+  return (
+    <CachedWebsiteLayout perspective="published" stega={false}>
+      {children}
+    </CachedWebsiteLayout>
+  )
+}
+async function CachedWebsiteLayout({
+  children,
+  perspective,
+  stega,
+}: {children: ReactNode} & DynamicFetchOptions) {
+  'use cache'
+  const settingsQuery = defineQuery(`*[_type == "settings"][0]`)
+  const {data} = await sanityFetch({query: settingsQuery, perspective, stega})
+
+  return (
+    <>
+      <Navbar data={data} />
+      {children}
+      <Footer data={data} />
+    </>
+  )
+}
+```
+
+## Simpler example: a single `<Footer>`
+
+Useful as a sanity check when adapting the pattern to a layout with only one data-driven section:
+
+```tsx
+// src/app/(website)/layout.tsx
+import {getDynamicFetchOptions, sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+import {draftMode} from 'next/headers'
+import {Suspense} from 'react'
+
+export default async function WebsiteLayout({children}: LayoutProps<'/'>) {
+  const {isEnabled: isDraftMode} = await draftMode()
+  return (
+    <>
+      {children}
+      {isDraftMode ? (
+        <Suspense fallback={<FooterFallback />}>
+          <DynamicFooter />
+        </Suspense>
+      ) : (
+        <Footer perspective="published" stega={false} />
+      )}
+    </>
+  )
+}
+async function DynamicFooter() {
+  const {perspective, stega} = await getDynamicFetchOptions()
+  return <Footer perspective={perspective} stega={stega} />
+}
+async function Footer({perspective, stega}: DynamicFetchOptions) {
+  'use cache'
+  const footerQuery = defineQuery(`*[_type == "footer"][0]`)
+  const {data} = await sanityFetch({query: footerQuery, perspective, stega})
+  return <footer>{/* use `data` to render stuff */}</footer>
+}
+function FooterFallback() {
+  return (
+    <footer>
+      <p>Loading footer...</p>
+    </footer>
+  )
+}
+```
+
+The non-draft `<Footer perspective="published" stega={false} />` is part of the static shell, so the whole layout is cached and revalidates only when content used by `sanityFetch` changes. In draft mode the layout still renders immediately from its static shell while `<DynamicFooter>` streams in.

--- a/.agents/skills/sanity-live-cache-components/reference/live-helpers.md
+++ b/.agents/skills/sanity-live-cache-components/reference/live-helpers.md
@@ -1,0 +1,220 @@
+# Live helpers: `client.ts` and `live.ts`
+
+## Contents
+
+- [`client.ts`](#clientts)
+- [`live.ts`](#livets)
+- [`sanityFetch`](#sanityfetch)
+- [`sanityFetchMetadata`](#sanityfetchmetadata)
+- [`getDynamicFetchOptions`](#getdynamicfetchoptions)
+- [`sanityFetchStaticParams`](#sanityfetchstaticparams)
+- [Anti-patterns to grep for](#anti-patterns-to-grep-for)
+
+## `client.ts`
+
+Projects typically have a `src/sanity/lib/client.ts` that exports a `createClient` instance.
+
+**If no `client.ts` exists yet**, use this shape as a starting point:
+
+```ts
+// src/sanity/lib/client.ts
+import {createClient} from 'next-sanity'
+
+export const client = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET!,
+  useCdn: true,
+  apiVersion: '2026-05-19',
+  perspective: 'published',
+  stega: {studioUrl: process.env.NEXT_PUBLIC_SANITY_STUDIO_URL || 'http://localhost:3333'},
+})
+```
+
+**If `client.ts` already exists**, leave its structure alone. Templates often centralize env-var reads in a separate `sanity/lib/api.ts` with an `assertValue` helper — keep that. Append only what's missing.
+
+- Use a modern `apiVersion` (e.g. today's date as a hardcoded string).
+- `stega.studioUrl` enables stega encoding. It can be a relative string when an embedded Studio is mounted via `NextStudio` from `next-sanity/studio`, otherwise an absolute URL (typically env-driven).
+- Changing `apiVersion` or removing existing `stega.*` options can break callers.
+- Never remove an existing `token` from `createClient`. Private datasets require a client token even for published-content fetches.
+
+## `live.ts`
+
+Create `src/sanity/lib/live.ts` alongside `client.ts`. If it already exists, append only what's missing.
+
+`SANITY_API_READ_TOKEN` must never reach the client bundle. If the project already keeps it in a dedicated server-only module (commonly `src/sanity/lib/token.ts` with `import 'server-only'` at the top), import the token from there instead of inlining the `process.env` read. The example below inlines it for brevity — swap in the existing module if there is one.
+
+```ts
+// src/sanity/lib/live.ts
+import {type QueryParams} from 'next-sanity'
+import {defineLive, resolvePerspectiveFromCookies, type LivePerspective} from 'next-sanity/live'
+import {cookies, draftMode} from 'next/headers'
+import {client} from './client'
+
+const token = process.env.SANITY_API_READ_TOKEN
+if (!token) {
+  throw new Error('Missing SANITY_API_READ_TOKEN')
+}
+
+export const {SanityLive, sanityFetch} = defineLive({
+  client,
+  serverToken: token,
+  browserToken: token,
+  strict: true,
+})
+
+export interface DynamicFetchOptions {
+  perspective: LivePerspective
+  stega: boolean
+}
+export async function getDynamicFetchOptions(): Promise<DynamicFetchOptions> {
+  const {isEnabled: isDraftMode} = await draftMode()
+  if (!isDraftMode) {
+    return {perspective: 'published', stega: false}
+  }
+
+  const jar = await cookies()
+  const perspective = await resolvePerspectiveFromCookies({cookies: jar})
+  return {perspective: perspective ?? 'drafts', stega: true}
+}
+
+// For usage within `generateStaticParams`
+export async function sanityFetchStaticParams<const QueryString extends string>({
+  query,
+  params = {},
+}: {
+  query: QueryString
+  params?: QueryParams
+}) {
+  'use cache'
+  const {data} = await sanityFetch({query, params, perspective: 'published', stega: false})
+  return {data}
+}
+
+// For usage within `generateMetadata` and `generateViewport`
+export async function sanityFetchMetadata<const QueryString extends string>({
+  query,
+  params = {},
+  perspective,
+}: {
+  query: QueryString
+  params?: QueryParams
+  perspective: LivePerspective
+}) {
+  'use cache'
+  const {data} = await sanityFetch({query, params, perspective, stega: false})
+  return {data}
+}
+```
+
+## `sanityFetch`
+
+For fetching data in React Server Components that have a `'use cache'` directive and are rendered (directly or transitively) from a `page.tsx` or `layout.tsx`.
+
+- `perspective` switches between published, drafts, and specific Sanity Content Releases.
+- `stega: true` (combined with `stega.studioUrl` in `createClient` and `<VisualEditing>` in the root layout) renders click-to-edit overlays.
+- `getDynamicFetchOptions` resolves `perspective` from the `sanity-preview-perspective` cookie, which `<VisualEditing>` manages when the app is rendered inside Presentation Tool's preview iframe.
+
+The async function that calls `sanityFetch` must carry `'use cache'` or `'use cache: remote'`, and must take `perspective` and `stega` as props. Never hardcode them.
+
+Pattern:
+
+```tsx
+import {sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+
+async function CachedComponent({slug, perspective, stega}: {slug: string} & DynamicFetchOptions) {
+  'use cache'
+  const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
+  const {data} = await sanityFetch({query: pageQuery, params: {slug}, perspective, stega})
+}
+```
+
+Anti-pattern (hardcoded options break Visual Editing and content-release previewing):
+
+```tsx
+async function CachedComponent({slug}: {slug: string}) {
+  'use cache'
+  const {data} = await sanityFetch({
+    query: pageQuery,
+    params: {slug},
+    perspective: 'published', // hardcoded
+    stega: false, // hardcoded
+  })
+}
+```
+
+### `sanityFetch` inside server actions
+
+`'use server'` boundaries cannot accept `perspective`/`stega` as props (server action inputs are untrusted). Resolve them inside the `'use server'` function and forward them to a separate `'use cache'` boundary:
+
+```tsx
+import {getDynamicFetchOptions, sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+
+async function fetchMore({page, perspective, stega}: {page: string} & DynamicFetchOptions) {
+  'use cache'
+  const pagesQuery = defineQuery(`*[_type == "page"][0...$page]`)
+  const {data} = await sanityFetch({query: pagesQuery, params: {page}, perspective, stega})
+  return data
+}
+async function renderMore({page}: {page: string}) {
+  'use server'
+  const {perspective, stega} = await getDynamicFetchOptions()
+  const data = await fetchMore({page, perspective, stega})
+}
+```
+
+Anti-patterns:
+
+- Hardcoding `perspective`/`stega` in the `'use cache'` helper.
+- Calling `sanityFetch` directly inside `'use server'` — it bypasses caching entirely.
+
+### `sanityFetch` inside `route.ts`
+
+Hardcode `stega: false` and resolve only `perspective`. Route handlers don't render a DOM next to `<VisualEditing>`, so stega encoding only inflates the payload (and can cause downstream errors).
+
+## `sanityFetchMetadata`
+
+For fetching data inside `generateMetadata`, `generateSitemaps`, `generateViewport`, `generateImageMetadata`, and the file-based metadata routes (`icon.tsx`, `apple-icon.tsx`, `manifest.ts`, `opengraph-image.tsx`, `twitter-image.tsx`, `robots.ts`, `sitemap.ts`).
+
+It's `sanityFetch` without `stega` (never wanted in these contexts) and without requiring `'use cache'` at the callsite — the helper already provides it.
+
+Presentation Tool can open an app in a standalone preview window, so the correct content release must still be reflected in `<title>` and friends. Always resolve `perspective`:
+
+```ts
+import {getDynamicFetchOptions, sanityFetchMetadata} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+
+export async function generateMetadata({params}: PageProps<'/[slug]'>) {
+  const [{slug}, {perspective}] = await Promise.all([params, getDynamicFetchOptions()])
+  const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
+  const {data} = await sanityFetchMetadata({query: pageQuery, params: {slug}, perspective})
+}
+```
+
+Anti-pattern: hardcoding `perspective: 'published'` — content-release previewing won't work.
+
+## `getDynamicFetchOptions`
+
+Resolves `perspective` and `stega` outside the `'use cache'` boundary so they can be passed in as plain props. Calls `cookies()`, which is a dynamic API, so the call must live inside a `<Suspense>` boundary (or a route with a sibling `loading.tsx`) so it doesn't block the static shell from streaming.
+
+Avoid calling `getDynamicFetchOptions` in the top-level body of a `layout.tsx` or `page.tsx` that should remain part of the static shell. The exception is routes that intentionally use a sibling `loading.tsx` for fallback UI (see [dynamic-segments.md](dynamic-segments.md)) — there the page can await `getDynamicFetchOptions` directly because `loading.tsx` provides the streaming fallback.
+
+When Cache Components are enabled, `<Suspense>` boundaries determine the static shell. For fully prerendered routes, render the Suspense tree only when in draft mode — see [three-layer-pattern.md](three-layer-pattern.md).
+
+## `sanityFetchStaticParams`
+
+Used inside `generateStaticParams`. `stega` is never wanted (the data feeds route params), and `perspective` cookies aren't available at build time anyway, so both are hardcoded.
+
+- Never call `sanityFetch` inside `generateStaticParams` — always use `sanityFetchStaticParams`.
+- Never call `sanityFetchStaticParams` outside `generateStaticParams`.
+
+## Anti-patterns to grep for
+
+When migrating an existing app, these are the strings to search for and refactor:
+
+- `perspective: 'published'` and `stega: false` hardcoded together in a `sanityFetch` call → replace with `perspective` and `stega` props sourced from `getDynamicFetchOptions` via the three-layer pattern.
+- `sanityFetch(` directly inside a function whose body starts with `'use server'` → split into a separate `'use cache'` helper and forward `perspective`/`stega` as props.
+- `sanityFetch(` inside `generateStaticParams` → swap for `sanityFetchStaticParams`.
+- `sanityFetch(` inside `generateMetadata` / `generateViewport` / `sitemap.ts` / `robots.ts` / `opengraph-image.tsx` etc. → swap for `sanityFetchMetadata` and resolve `perspective` via `getDynamicFetchOptions`.
+- `await draftMode()` immediately followed by `await getDynamicFetchOptions()` at the top of a `page.tsx` or `layout.tsx` without a sibling `loading.tsx` → move the dynamic-API calls into a child component wrapped in `<Suspense>` so the static shell can prerender.

--- a/.agents/skills/sanity-live-cache-components/reference/three-layer-pattern.md
+++ b/.agents/skills/sanity-live-cache-components/reference/three-layer-pattern.md
@@ -1,0 +1,146 @@
+# Three-layer component pattern
+
+The core architecture for every route that can be fully statically prerendered and cached.
+
+## Contents
+
+- [Structure](#structure)
+- [`generateStaticParams` for dynamic routes](#generatestaticparams-for-dynamic-routes)
+- [Layer 1: Page component](#layer-1-page-component)
+- [Layer 2: Dynamic component](#layer-2-dynamic-component)
+- [Layer 3: Cached component](#layer-3-cached-component)
+- [`searchParams` and other dynamic APIs](#searchparams-and-other-dynamic-apis)
+
+## Structure
+
+```text
+Page/Layout (Layer 1)
+  ├── NOT draft mode → <CachedX perspective="published" stega={false} />  (no Suspense)
+  └── draft mode → <Suspense fallback={...}>
+                      <DynamicX params={params} />  (Layer 2)
+                        └── <CachedX params={await params} perspective={p} stega={s} />  (Layer 3)
+```
+
+## `generateStaticParams` for dynamic routes
+
+The examples below use `/[slug]/page.tsx`, which needs:
+
+```tsx
+// src/app/[slug]/page.tsx
+import {sanityFetchStaticParams} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+
+export async function generateStaticParams() {
+  const pageSlugsQuery = defineQuery(
+    `*[_type == "page" && defined(slug.current)]{"slug": slug.current}`,
+  )
+  const {data} = await sanityFetchStaticParams({query: pageSlugsQuery})
+  return data
+}
+```
+
+For `/layout.tsx` or `/page.tsx` (no params), skip the `params` handling.
+
+## Layer 1: Page component
+
+Calls `draftMode()` and branches:
+
+```tsx
+// src/app/[slug]/page.tsx (continued)
+import {draftMode} from 'next/headers'
+import {Suspense} from 'react'
+
+export default async function Page({params}: PageProps<'/[slug]'>) {
+  const {isEnabled: isDraftMode} = await draftMode()
+  if (isDraftMode) {
+    return (
+      <Suspense fallback={<PageFallback />}>
+        <DynamicPage
+          // do not await `params` here, it needs to be awaited in `<DynamicPage>` so the Suspense boundary works
+          params={params}
+        />
+      </Suspense>
+    )
+  }
+  const {slug} = await params
+  return <CachedPage slug={slug} perspective="published" stega={false} />
+}
+```
+
+Notes:
+
+- `Page` does **not** have a `'use cache'` directive. `draftMode()` is allowed inside `'use cache'`, but `Page` also `awaits` `params` (and may call `getDynamicFetchOptions()`, which reads `cookies()`), and those dynamic APIs are not allowed inside `'use cache'`. It's enough for `<CachedPage>` (Layer 3) to carry `'use cache'` for `Page` to be prerendered as part of the static shell.
+- Requires `generateStaticParams` if `params` is used as input to `sanityFetch`.
+- Not in draft mode → no `<Suspense>` boundary, maximizes the static shell.
+- In draft mode → `<DynamicPage />` inside `<Suspense>` will suspend twice:
+  1. when `<DynamicPage>` awaits `getDynamicFetchOptions()`
+  2. when `<CachedPage />` awaits `sanityFetch` with the resolved `perspective`/`stega`
+
+  A good fallback skeleton that doesn't cause layout shift is highly recommended.
+
+## Layer 2: Dynamic component
+
+Resolves `params`, `cookies()`, and `headers()` outside the cache boundary and passes plain props in:
+
+```tsx
+// src/app/[slug]/page.tsx (continued)
+import {getDynamicFetchOptions} from '@/sanity/lib/live'
+
+async function DynamicPage({params}: Pick<PageProps<'/[slug]'>, 'params'>) {
+  const [{slug}, {perspective, stega}] = await Promise.all([params, getDynamicFetchOptions()])
+
+  return <CachedPage slug={slug} perspective={perspective} stega={stega} />
+}
+```
+
+`draftMode()` is the only dynamic API allowed inside `'use cache'`, but in this pattern it isn't needed in Layer 3 because `perspective` and `stega` already encode the draft state.
+
+## Layer 3: Cached component
+
+Has `'use cache'` and only receives plain, serializable props:
+
+```tsx
+// src/app/[slug]/page.tsx (continued)
+import {sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+
+async function CachedPage({
+  slug,
+  perspective,
+  stega,
+}: Awaited<PageProps<'/[slug]'>['params']> & DynamicFetchOptions) {
+  'use cache'
+  const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
+  const {data} = await sanityFetch({
+    query: pageQuery,
+    params: {slug},
+    perspective,
+    stega,
+  })
+  return <article>{/* use `data` to render stuff */}</article>
+}
+```
+
+## `searchParams` and other dynamic APIs
+
+If `searchParams` or other dynamic APIs are inputs to `sanityFetch` (or `params` is used without `generateStaticParams` or a `loading.tsx`), always render the `<Suspense>` tree and **stop branching on `draftMode`**. See [the streaming guide](https://nextjs.org/docs/app/guides/streaming#when-to-use-loadingjs-vs-suspense) for picking between `loading.tsx` and `<Suspense>`.
+
+```tsx
+// src/app/[slug]/page.tsx (continued)
+import {Suspense} from 'react'
+
+// Do not export an async function here, to avoid accidentally blocking render while awaiting a dynamic API
+export default function Page({params}: PageProps<'/[slug]'>) {
+  return (
+    <Suspense
+      // not optional — no draftMode branch means a missing skeleton causes massive layout shift
+      fallback={<PageFallback />}
+    >
+      <DynamicPage
+        // do not await `params` here, it needs to be awaited in `<DynamicPage>` so the Suspense boundary works
+        params={params}
+      />
+    </Suspense>
+  )
+}
+```

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 [![Deploy with Vercel](https://vercel.com/button)][vercel-deploy]
 
-This starter is a statically generated personal website that uses [Next.js][nextjs] for the frontend and [Sanity][sanity-homepage] to handle its content. It comes with a native Sanity Studio that offers features like real-time collaboration and visual editing with live updates using [Presentation][presentation].
+This starter is a personal website that uses [Next.js][nextjs] for the frontend and [Sanity][sanity-homepage] to handle its content. It runs with [Next.js Cache Components][cache-components] enabled: every page prerenders into a static shell and refreshes on content changes through Sanity Live — no rebuild required. The template comes with a native Sanity Studio that offers features like real-time collaboration and visual editing with live updates using [Presentation][presentation].
 
 The Studio connects to Sanity Content Lake, which gives you hosted content APIs with a flexible query language, on-demand image transformations, powerful patching, and more. You can use this starter to kick-start a personal website or learn these technologies.
 
 ## Features
 
-- A performant, static personal website with editable projects
+- Runs on [Next.js Cache Components][cache-components] — pages prerender into a static shell and refresh on content changes through Sanity Live
+- A performant personal website with editable projects
 - A native and customizable authoring environment, accessible on `yourpersonalwebsite.com/studio`
 - Real-time and collaborative content editing with fine-grained revision history
 - Side-by-side instant content preview that works across your whole site
@@ -23,6 +24,7 @@ The Studio connects to Sanity Content Lake, which gives you hosted content APIs 
 - [Table of Contents](#table-of-contents)
 - [Project Overview](#project-overview)
   - [Important files and folders](#important-files-and-folders)
+  - [Cache Components](#cache-components)
 - [ Getting Started](#configuration)
   - [Step 1. Initialize template with Sanity CLI](#initialize-template-with-sanity-cli)
   - [Step 2. Run app locally in development mode](#run-app-locally-in-development-mode)
@@ -46,15 +48,39 @@ The Studio connects to Sanity Content Lake, which gives you hosted content APIs 
 
 ### Important files and folders
 
-| File(s)                                      | Description                                             |
-| -------------------------------------------- | ------------------------------------------------------- |
-| `sanity.config.ts`                           | Config file for Sanity Studio                           |
-| `sanity.cli.ts`                              | Config file for Sanity CLI                              |
-| `/app/studio/[[...tool]]/Studio.tsx`         | Where Sanity Studio is mounted                          |
-| `/app/api/draft-mode/enable/route.ts`        | Serverless route for triggering Draft mode              |
-| `/sanity/schemas`                            | Where Sanity Studio gets its content types from         |
-| `/sanity/plugins`                            | Where the advanced Sanity Studio customization is setup |
-| `/sanity/lib/api.ts`,`/sanity/lib/client.ts` | Configuration for the Sanity Content Lake client        |
+| File(s)                                      | Description                                                                                  |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `sanity.config.ts`                           | Config file for Sanity Studio                                                                |
+| `sanity.cli.ts`                              | Config file for Sanity CLI                                                                   |
+| `next.config.ts`                             | Enables [Cache Components][cache-components] and sets the default `cacheLife` to Sanity Live |
+| `/app/studio/[[...tool]]/Studio.tsx`         | Where Sanity Studio is mounted                                                               |
+| `/app/api/draft-mode/enable/route.ts`        | Serverless route for triggering Draft mode                                                   |
+| `/sanity/schemas`                            | Where Sanity Studio gets its content types from                                              |
+| `/sanity/plugins`                            | Where the advanced Sanity Studio customization is setup                                      |
+| `/sanity/lib/api.ts`,`/sanity/lib/client.ts` | Configuration for the Sanity Content Lake client                                             |
+| `/sanity/lib/live.ts`                        | `sanityFetch`, `sanityFetchMetadata`, `sanityFetchStaticParams`, `getDynamicFetchOptions`    |
+
+### Cache Components
+
+The template enables Next.js [Cache Components][cache-components] in [`next.config.ts`](./next.config.ts):
+
+```ts
+import {sanity} from 'next-sanity/live/cache-life'
+
+const config: NextConfig = {
+  cacheComponents: true,
+  cacheLife: {default: sanity},
+}
+```
+
+Data fetching follows the three-layer (Page → Dynamic → Cached) pattern from the [`sanity-live-cache-components`](https://github.com/sanity-io/next-sanity/tree/main/skills/sanity-live-cache-components) skill, applied in:
+
+- [`app/(website)/layout.tsx`](<./app/(website)/layout.tsx>) — `Dynamic/CachedNavbar` and `Dynamic/CachedFooter` share a `'use cache'` `fetchSettings` helper
+- [`app/(website)/page.tsx`](<./app/(website)/page.tsx>) — homepage
+- [`app/(website)/[slug]/page.tsx`](<./app/(website)/[slug]/page.tsx>) — dynamic page route
+- [`app/(website)/projects/[slug]/page.tsx`](<./app/(website)/projects/[slug]/page.tsx>) — dynamic project route
+
+Every cached leaf takes `perspective` and `stega` as plain props sourced from `getDynamicFetchOptions()`, so Visual Editing overlays and content-release previewing keep working in Draft Mode while the static shell is fully prerendered in production.
 
 ## Getting Started
 
@@ -158,3 +184,4 @@ You can remove it by deleting the `IntroTemplate` component in `/app/(website)/l
 [vercel-github]: https://github.com/vercel/next.js/discussions
 [personal-website-pages]: https://github.com/sanity-io/template-nextjs-personal-website
 [presentation]: https://www.sanity.io/docs/presentation
+[cache-components]: https://nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents

--- a/app/(website)/[slug]/page.tsx
+++ b/app/(website)/[slug]/page.tsx
@@ -1,17 +1,23 @@
 import {CustomPortableText} from '@/components/CustomPortableText'
 import {Header} from '@/components/Header'
-import {sanityFetch} from '@/sanity/lib/live'
+import {
+  type DynamicFetchOptions,
+  getDynamicFetchOptions,
+  sanityFetch,
+  sanityFetchMetadata,
+  sanityFetchStaticParams,
+} from '@/sanity/lib/live'
 import {slugsByTypeQuery, type SlugsByTypeQueryParams} from '@/sanity/lib/queries'
 import type {Metadata, ResolvingMetadata} from 'next'
 import {defineQuery} from 'next-sanity'
+import {draftMode} from 'next/headers'
 import {notFound} from 'next/navigation'
+import {Suspense} from 'react'
 
 export async function generateStaticParams() {
-  const {data} = await sanityFetch({
+  const {data} = await sanityFetchStaticParams({
     query: slugsByTypeQuery,
     params: {type: 'page'} satisfies SlugsByTypeQueryParams,
-    perspective: 'published',
-    stega: false,
   })
   return data
 }
@@ -20,17 +26,17 @@ export async function generateMetadata(
   {params}: PageProps<'/[slug]'>,
   parent: ResolvingMetadata,
 ): Promise<Metadata> {
-  const {slug} = await params
+  const [{slug}, {perspective}] = await Promise.all([params, getDynamicFetchOptions()])
   const slugPageMetadataQuery = defineQuery(`
     *[_type == "page" && slug.current == $slug][0] {
       title,
       "overview": pt::text(overview),
     }
   `)
-  const {data} = await sanityFetch({
+  const {data} = await sanityFetchMetadata({
     query: slugPageMetadataQuery,
     params: {slug},
-    stega: false,
+    perspective,
   })
 
   return {
@@ -40,7 +46,29 @@ export async function generateMetadata(
 }
 
 export default async function SlugPage({params}: PageProps<'/[slug]'>) {
-  const {slug} = await params
+  const {isEnabled: isDraftMode} = await draftMode()
+  if (!isDraftMode) {
+    const {slug} = await params
+    return <CachedSlugPage slug={slug} perspective="published" stega={false} />
+  }
+  return (
+    <Suspense>
+      <DynamicSlugPage params={params} />
+    </Suspense>
+  )
+}
+
+async function DynamicSlugPage({params}: Pick<PageProps<'/[slug]'>, 'params'>) {
+  const [{slug}, {perspective, stega}] = await Promise.all([params, getDynamicFetchOptions()])
+  return <CachedSlugPage slug={slug} perspective={perspective} stega={stega} />
+}
+
+async function CachedSlugPage({
+  slug,
+  perspective,
+  stega,
+}: Awaited<PageProps<'/[slug]'>['params']> & DynamicFetchOptions) {
+  'use cache'
   const slugPageQuery = defineQuery(`
     *[_type == "page" && slug.current == $slug][0] {
       _id,
@@ -51,7 +79,7 @@ export default async function SlugPage({params}: PageProps<'/[slug]'>) {
       "slug": slug.current,
     }
   `)
-  const {data} = await sanityFetch({query: slugPageQuery, params: {slug}})
+  const {data} = await sanityFetch({query: slugPageQuery, params: {slug}, perspective, stega})
 
   if (!data?._id) notFound()
 

--- a/app/(website)/layout.tsx
+++ b/app/(website)/layout.tsx
@@ -2,7 +2,13 @@ import '@/styles/index.css'
 import {CustomPortableText} from '@/components/CustomPortableText'
 import {Navbar} from '@/components/Navbar'
 import IntroTemplate from '@/intro-template'
-import {sanityFetch, SanityLive} from '@/sanity/lib/live'
+import {
+  type DynamicFetchOptions,
+  getDynamicFetchOptions,
+  sanityFetch,
+  sanityFetchMetadata,
+  SanityLive,
+} from '@/sanity/lib/live'
 import {settingsQuery} from '@/sanity/lib/queries'
 import {urlForOpenGraphImage} from '@/sanity/lib/utils'
 import {SpeedInsights} from '@vercel/speed-insights/next'
@@ -16,6 +22,7 @@ import {handleError} from './client-functions'
 import {DraftModeToast} from './DraftModeToast'
 
 export async function generateMetadata(): Promise<Metadata> {
+  const {perspective} = await getDynamicFetchOptions()
   const layoutMetadataQuery = defineQuery(`{
     "settings": *[_type == "settings"][0]{ogImage},
     "home": *[_type == "home"][0]{
@@ -25,7 +32,7 @@ export async function generateMetadata(): Promise<Metadata> {
   }`)
   const {
     data: {settings, home},
-  } = await sanityFetch({query: layoutMetadataQuery, stega: false})
+  } = await sanityFetchMetadata({query: layoutMetadataQuery, perspective})
 
   const ogImage = urlForOpenGraphImage(settings?.ogImage)
   return {
@@ -40,30 +47,32 @@ export async function generateMetadata(): Promise<Metadata> {
 export const viewport: Viewport = {themeColor: '#000'}
 
 export default async function PersonalLayout({children}: LayoutProps<'/'>) {
-  const {data} = await sanityFetch({query: settingsQuery})
+  const {isEnabled: isDraftMode} = await draftMode()
   return (
     <>
       <div className="flex min-h-screen flex-col bg-white text-black">
-        <Navbar data={data} />
+        {isDraftMode ? (
+          <Suspense fallback={<NavbarFallback />}>
+            <DynamicNavbar />
+          </Suspense>
+        ) : (
+          <CachedNavbar perspective="published" stega={false} />
+        )}
         <div className="mt-20 flex-grow px-4 md:px-16 lg:px-32">{children}</div>
-        {Array.isArray(data?.footer) && (
-          <footer className="bottom-0 w-full bg-white py-12 text-center md:py-20">
-            <CustomPortableText
-              id={data._id}
-              type={data._type}
-              path={['footer']}
-              paragraphClasses="text-md md:text-xl"
-              value={data.footer}
-            />
-          </footer>
+        {isDraftMode ? (
+          <Suspense>
+            <DynamicFooter />
+          </Suspense>
+        ) : (
+          <CachedFooter perspective="published" stega={false} />
         )}
         <Suspense>
           <IntroTemplate />
         </Suspense>
       </div>
       <Toaster />
-      <SanityLive onError={handleError} />
-      {(await draftMode()).isEnabled && (
+      <SanityLive onError={handleError} includeDrafts={isDraftMode} />
+      {isDraftMode && (
         <>
           <DraftModeToast
             action={async () => {
@@ -81,5 +90,67 @@ export default async function PersonalLayout({children}: LayoutProps<'/'>) {
       )}
       <SpeedInsights />
     </>
+  )
+}
+
+/**
+ * Shared cache leaf — both the navbar and footer derive from the same `settingsQuery`, so
+ * neither has to wait independently for the same data.
+ */
+async function fetchSettings({perspective, stega}: DynamicFetchOptions) {
+  'use cache'
+  const {data} = await sanityFetch({query: settingsQuery, perspective, stega})
+  return data
+}
+
+async function DynamicNavbar() {
+  const {perspective, stega} = await getDynamicFetchOptions()
+  return <CachedNavbar perspective={perspective} stega={stega} />
+}
+
+async function CachedNavbar({perspective, stega}: DynamicFetchOptions) {
+  'use cache'
+  const data = await fetchSettings({perspective, stega})
+  return <Navbar data={data} />
+}
+
+/**
+ * Mirrors the real `<Navbar>` shell so the static fallback occupies the same vertical space.
+ * Width of the placeholder link is arbitrary — height is what matters to avoid layout shift.
+ */
+function NavbarFallback() {
+  return (
+    <header
+      aria-busy
+      className="sticky top-0 z-10 flex flex-wrap items-center gap-x-5 bg-white/80 px-4 py-4 backdrop-blur md:px-16 md:py-5 lg:px-32"
+    >
+      <span className="text-lg md:text-xl" aria-hidden>
+        <span className="inline-block h-[1em] w-24 animate-pulse rounded bg-gray-200 align-middle md:w-32" />
+      </span>
+    </header>
+  )
+}
+
+async function DynamicFooter() {
+  const {perspective, stega} = await getDynamicFetchOptions()
+  return <CachedFooter perspective={perspective} stega={stega} />
+}
+
+async function CachedFooter({perspective, stega}: DynamicFetchOptions) {
+  'use cache'
+  const data = await fetchSettings({perspective, stega})
+  if (!Array.isArray(data?.footer)) {
+    return null
+  }
+  return (
+    <footer className="bottom-0 w-full bg-white py-12 text-center md:py-20">
+      <CustomPortableText
+        id={data._id}
+        type={data._type}
+        path={['footer']}
+        paragraphClasses="text-md md:text-xl"
+        value={data.footer}
+      />
+    </footer>
   )
 }

--- a/app/(website)/page.tsx
+++ b/app/(website)/page.tsx
@@ -3,12 +3,36 @@ import {Header} from '@/components/Header'
 import ImageBox from '@/components/ImageBox'
 import {OptimisticSortOrder} from '@/components/OptimisticSortOrder'
 import {studioUrl} from '@/sanity/lib/api'
-import {sanityFetch} from '@/sanity/lib/live'
+import {
+  type DynamicFetchOptions,
+  getDynamicFetchOptions,
+  sanityFetch,
+} from '@/sanity/lib/live'
 import {resolveHref} from '@/sanity/lib/utils'
 import {createDataAttribute, defineQuery} from 'next-sanity'
+import {draftMode} from 'next/headers'
 import Link from 'next/link'
+import {Suspense} from 'react'
 
 export default async function IndexPage() {
+  const {isEnabled: isDraftMode} = await draftMode()
+  if (!isDraftMode) {
+    return <CachedHome perspective="published" stega={false} />
+  }
+  return (
+    <Suspense>
+      <DynamicHome />
+    </Suspense>
+  )
+}
+
+async function DynamicHome() {
+  const {perspective, stega} = await getDynamicFetchOptions()
+  return <CachedHome perspective={perspective} stega={stega} />
+}
+
+async function CachedHome({perspective, stega}: DynamicFetchOptions) {
+  'use cache'
   const homePageQuery = defineQuery(`
     *[_type == "home"][0]{
       _id,
@@ -29,7 +53,7 @@ export default async function IndexPage() {
       title,
     }
   `)
-  const {data} = await sanityFetch({query: homePageQuery})
+  const {data} = await sanityFetch({query: homePageQuery, perspective, stega})
 
   if (!data) {
     return (

--- a/app/(website)/projects/[slug]/page.tsx
+++ b/app/(website)/projects/[slug]/page.tsx
@@ -2,20 +2,26 @@ import {CustomPortableText} from '@/components/CustomPortableText'
 import {Header} from '@/components/Header'
 import ImageBox from '@/components/ImageBox'
 import {studioUrl} from '@/sanity/lib/api'
-import {sanityFetch} from '@/sanity/lib/live'
+import {
+  type DynamicFetchOptions,
+  getDynamicFetchOptions,
+  sanityFetch,
+  sanityFetchMetadata,
+  sanityFetchStaticParams,
+} from '@/sanity/lib/live'
 import {slugsByTypeQuery, type SlugsByTypeQueryParams} from '@/sanity/lib/queries'
 import {urlForOpenGraphImage} from '@/sanity/lib/utils'
 import type {Metadata, ResolvingMetadata} from 'next'
 import {createDataAttribute, defineQuery} from 'next-sanity'
+import {draftMode} from 'next/headers'
 import Link from 'next/link'
 import {notFound} from 'next/navigation'
+import {Suspense} from 'react'
 
 export async function generateStaticParams() {
-  const {data} = await sanityFetch({
+  const {data} = await sanityFetchStaticParams({
     query: slugsByTypeQuery,
     params: {type: 'project'} satisfies SlugsByTypeQueryParams,
-    stega: false,
-    perspective: 'published',
   })
   return data
 }
@@ -24,7 +30,7 @@ export async function generateMetadata(
   {params}: PageProps<'/projects/[slug]'>,
   parent: ResolvingMetadata,
 ): Promise<Metadata> {
-  const {slug} = await params
+  const [{slug}, {perspective}] = await Promise.all([params, getDynamicFetchOptions()])
   const projectSlugPageMetadataQuery = defineQuery(`
     *[_type == "project" && slug.current == $slug][0] {
       coverImage,
@@ -32,10 +38,10 @@ export async function generateMetadata(
       "overview": pt::text(overview),
     }
   `)
-  const {data} = await sanityFetch({
+  const {data} = await sanityFetchMetadata({
     query: projectSlugPageMetadataQuery,
     params: {slug},
-    stega: false,
+    perspective,
   })
 
   const ogImage = urlForOpenGraphImage(data?.coverImage)
@@ -47,7 +53,29 @@ export async function generateMetadata(
 }
 
 export default async function ProjectSlugPage({params}: PageProps<'/projects/[slug]'>) {
-  const {slug} = await params
+  const {isEnabled: isDraftMode} = await draftMode()
+  if (!isDraftMode) {
+    const {slug} = await params
+    return <CachedProjectSlugPage slug={slug} perspective="published" stega={false} />
+  }
+  return (
+    <Suspense>
+      <DynamicProjectSlugPage params={params} />
+    </Suspense>
+  )
+}
+
+async function DynamicProjectSlugPage({params}: Pick<PageProps<'/projects/[slug]'>, 'params'>) {
+  const [{slug}, {perspective, stega}] = await Promise.all([params, getDynamicFetchOptions()])
+  return <CachedProjectSlugPage slug={slug} perspective={perspective} stega={stega} />
+}
+
+async function CachedProjectSlugPage({
+  slug,
+  perspective,
+  stega,
+}: Awaited<PageProps<'/projects/[slug]'>['params']> & DynamicFetchOptions) {
+  'use cache'
   const projectSlugPageQuery = defineQuery(`
     *[_type == "project" && slug.current == $slug][0] {
       _id,
@@ -63,7 +91,12 @@ export default async function ProjectSlugPage({params}: PageProps<'/projects/[sl
       title,
     }
   `)
-  const {data} = await sanityFetch({query: projectSlugPageQuery, params: {slug}})
+  const {data} = await sanityFetch({
+    query: projectSlugPageQuery,
+    params: {slug},
+    perspective,
+    stega,
+  })
 
   if (!data?._id) notFound()
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
-import {NextConfig} from 'next'
+import type {NextConfig} from 'next'
+import {sanity} from 'next-sanity/live/cache-life'
 
 const config: NextConfig = {
+  cacheComponents: true,
+  cacheLife: {default: sanity},
   reactCompiler: true,
   images: {
     remotePatterns: [{hostname: 'cdn.sanity.io'}],

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "classnames": "2.5.1",
         "date-fns": "4.1.0",
         "next": "16.2.6",
-        "next-sanity": "13.0.0",
+        "next-sanity": "13.0.2",
         "react": "19.2.6",
         "react-dom": "19.2.6",
         "react-live-transitions": "0.2.0",
@@ -12347,9 +12347,9 @@
       }
     },
     "node_modules/next-sanity": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/next-sanity/-/next-sanity-13.0.0.tgz",
-      "integrity": "sha512-Ue4MblfAj90IQFGjrGGkjleDsgw/kn3iWHpXEhjukw7RWXQRiaEJ4PQKoD19cixjvAKIQvXmXy50ltSFF58/5Q==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/next-sanity/-/next-sanity-13.0.2.tgz",
+      "integrity": "sha512-o9d3lmI873yoI+mCIBD44QinycElhlO4osv58+yKY6k58LHFlCaMOuzXuF8TEocnqvoXpGFjfZpCJo2d8sWFtg==",
       "license": "MIT",
       "dependencies": {
         "@portabletext/react": "^6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "classnames": "2.5.1",
         "date-fns": "4.1.0",
         "next": "16.2.6",
-        "next-sanity": "12.4.5",
+        "next-sanity": "13.0.0",
         "react": "19.2.6",
         "react-dom": "19.2.6",
         "react-live-transitions": "0.2.0",
@@ -10521,9 +10521,9 @@
       "license": "ISC"
     },
     "node_modules/groq": {
-      "version": "5.25.1",
-      "resolved": "https://registry.npmjs.org/groq/-/groq-5.25.1.tgz",
-      "integrity": "sha512-EzSkxI0r6Wf9BkdDpSpcCmuTe32PcMAZPuWyOixVnOLX4ZrapEqW/UW84SrERGDyiUbm4tmZx3s5HS3IyqAalg==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/groq/-/groq-5.26.0.tgz",
+      "integrity": "sha512-lIXBDJjRBZckV7pzQ1Yt/PwiKLOiVkdZVDey6gLZS4cH2xB3saRBX0OCWdqX1sUbpeLDtWL5OSYpKXZaDxiPQg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
@@ -12347,20 +12347,18 @@
       }
     },
     "node_modules/next-sanity": {
-      "version": "12.4.5",
-      "resolved": "https://registry.npmjs.org/next-sanity/-/next-sanity-12.4.5.tgz",
-      "integrity": "sha512-KXqUOfxk8FsVOzKbISRcYCqMxGbUbWO7spYjRHQxv9KyFbYH3ofMHeAvj5uojZ1it+/y2nKFcUk9s4EUOWVwbA==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/next-sanity/-/next-sanity-13.0.0.tgz",
+      "integrity": "sha512-Ue4MblfAj90IQFGjrGGkjleDsgw/kn3iWHpXEhjukw7RWXQRiaEJ4PQKoD19cixjvAKIQvXmXy50ltSFF58/5Q==",
       "license": "MIT",
       "dependencies": {
         "@portabletext/react": "^6.2.0",
         "@sanity/client": "^7.22.0",
-        "@sanity/comlink": "^4.0.1",
-        "@sanity/presentation-comlink": "^2.0.1",
+        "@sanity/generate-help-url": "^4.0.0",
         "@sanity/preview-url-secret": "^4.0.6",
-        "@sanity/visual-editing": "^5.3.4",
+        "@sanity/visual-editing": "^5.3.6",
         "@sanity/webhook": "^4.0.4",
-        "dequal": "^2.0.3",
-        "groq": "^5.24.0",
+        "groq": "^5.26.0",
         "history": "^5.3.0"
       },
       "engines": {
@@ -12371,7 +12369,7 @@
         "next": "^16.0.0-0",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
-        "sanity": "^5.24.0",
+        "sanity": "^5.26.0",
         "styled-components": "^6.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "classnames": "2.5.1",
     "date-fns": "4.1.0",
     "next": "16.2.6",
-    "next-sanity": "13.0.0",
+    "next-sanity": "13.0.2",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "react-live-transitions": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "classnames": "2.5.1",
     "date-fns": "4.1.0",
     "next": "16.2.6",
-    "next-sanity": "12.4.5",
+    "next-sanity": "13.0.0",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "react-live-transitions": "0.2.0",

--- a/sanity/lib/live.ts
+++ b/sanity/lib/live.ts
@@ -1,4 +1,6 @@
-import {defineLive} from 'next-sanity/live'
+import {type QueryParams} from 'next-sanity'
+import {defineLive, resolvePerspectiveFromCookies, type LivePerspective} from 'next-sanity/live'
+import {cookies, draftMode} from 'next/headers'
 import {client} from './client'
 import {token} from './token'
 
@@ -6,4 +8,64 @@ export const {SanityLive, sanityFetch} = defineLive({
   client,
   serverToken: token,
   browserToken: token,
+  strict: true,
 })
+
+export interface DynamicFetchOptions {
+  perspective: LivePerspective
+  stega: boolean
+}
+
+/**
+ * Resolves `perspective` and `stega` outside of any `'use cache'` boundary so they can be
+ * passed as plain serializable props into a cached leaf. Calls `cookies()`, so callers must
+ * be wrapped in `<Suspense>` (or sit next to a `loading.tsx`).
+ */
+export async function getDynamicFetchOptions(): Promise<DynamicFetchOptions> {
+  const {isEnabled: isDraftMode} = await draftMode()
+  if (!isDraftMode) {
+    return {perspective: 'published', stega: false}
+  }
+
+  const jar = await cookies()
+  const perspective = await resolvePerspectiveFromCookies({cookies: jar})
+  return {perspective: perspective ?? 'drafts', stega: true}
+}
+
+/**
+ * For usage within `generateStaticParams`.
+ *
+ * Hardcodes `perspective: 'published'` and `stega: false` because perspective cookies aren't
+ * available at build time and stega data is never wanted as route params.
+ */
+export async function sanityFetchStaticParams<const QueryString extends string>({
+  query,
+  params = {},
+}: {
+  query: QueryString
+  params?: QueryParams
+}) {
+  'use cache'
+  const {data} = await sanityFetch({query, params, perspective: 'published', stega: false})
+  return {data}
+}
+
+/**
+ * For usage within `generateMetadata`, `generateViewport`, `sitemap.ts`, `robots.ts`,
+ * `opengraph-image.tsx`, and other file-based metadata routes. `stega` is hardcoded `false`
+ * because metadata never renders alongside `<VisualEditing>`, but `perspective` must still
+ * be resolved (Presentation Tool can open a standalone preview window).
+ */
+export async function sanityFetchMetadata<const QueryString extends string>({
+  query,
+  params = {},
+  perspective,
+}: {
+  query: QueryString
+  params?: QueryParams
+  perspective: LivePerspective
+}) {
+  'use cache'
+  const {data} = await sanityFetch({query, params, perspective, stega: false})
+  return {data}
+}

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "sanity-live-cache-components": {
+      "source": "sanity-io/next-sanity",
+      "sourceType": "github",
+      "skillPath": "skills/sanity-live-cache-components/SKILL.md",
+      "computedHash": "354498f97fd57877d48f4cfe6e8838de610995a6d53bef0cee3fe5b5ef9fad7e"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adopts `next-sanity@13` (pinned exact, matching the template's version convention) and migrates this template to Next.js Cache Components per the [`sanity-live-cache-components`](https://github.com/sanity-io/next-sanity/tree/main/skills/sanity-live-cache-components) skill.

- `next.config.ts`: `cacheComponents: true` + `cacheLife.default = sanity` preset.
- `sanity/lib/live.ts`: `strict: true`; exports `getDynamicFetchOptions`, `sanityFetchMetadata`, `sanityFetchStaticParams`, and a `DynamicFetchOptions` type.
- `app/(website)/layout.tsx`: shared `'use cache'` `fetchSettings` helper feeds `Dynamic/CachedNavbar` and `Dynamic/CachedFooter`. Navbar uses a height-stable `NavbarFallback`; footer's `<Suspense>` has no fallback (below the fold). `<SanityLive includeDrafts={isDraftMode} onError={handleError} />`. `generateMetadata` now uses `sanityFetchMetadata` + `getDynamicFetchOptions`.
- `app/(website)/page.tsx`, `[slug]/page.tsx`, `projects/[slug]/page.tsx`: three-layer pattern (Page → Dynamic → Cached). `generateStaticParams` → `sanityFetchStaticParams`; `generateMetadata` → `sanityFetchMetadata`. Page-level `<Suspense>` boundaries deliberately have no fallback — the page title is a `<div>`, so there's no reliably-knowable height to skeleton without risking layout shift.
- `README.md` updated to document Cache Components with a link to the [official Next.js docs](https://nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents).
- Skill installed locally under `.agents/skills/sanity-live-cache-components/` with `skills-lock.json` manifest.

`npm run type-check` passes.

## Verification (`next dev`)

Verified locally with `next --turbopack` against the `personal-website-dev` Sanity dataset.

### Draft mode OFF

| Route | HTTP | Size | Stega ZW chars | `<header sticky>` | `<footer>` | VisualEditing | DraftModeToast | NavbarFallback (`aria-busy`) |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| `/` | 200 | 77 KB | 0 | yes | yes | 0 | 0 | 0 |
| `/about` | 200 | 89 KB | 0 | yes | yes | 0 | 0 | 0 |
| `/projects/project-a` | 200 | 92 KB | 0 | yes | yes | 0 | 0 | 0 |

All Sanity fetches went out with `perspective=published` and the `next-loader.fetch.cache-components` tag. No Cache Components diagnostics or `cookies()`-in-cache warnings.

### Draft mode ON (via `/api/draft-mode/enable`)

Generated a preview secret via `createPreviewSecret`, exchanged it for the `__prerender_bypass` + `sanity-preview-perspective=drafts` cookies, then re-requested each route:

| Route | HTTP | Size | Stega ZW chars | VisualEditing refs | DraftModeToast | NavbarFallback streamed |
| --- | --- | --- | --- | --- | --- | --- |
| `/` | 200 | 468 KB | 118,664 | 2 | yes | yes |
| `/about` | 200 | 264 KB | 27,568 | 2 | yes | yes |
| `/projects/project-a` | 200 | 276 KB | 40,320 | 2 | yes | yes |

NavbarFallback streams in and is then swapped for the real `<Navbar>` once `DynamicNavbar` resolves `perspective`/`stega` — the fallback shares the navbar's `<header>` shell + padding classes, so swapping causes no layout shift.

### `/studio` isolation

`/studio` returns 200 with **0** `SanityLive` and **0** `VisualEditing` references, confirming the `(website)` route-group split keeps live/preview infrastructure out of the embedded studio's layout.

## Test plan

- [x] `npm run dev` with draft mode **disabled**: routes render from the static shell with no stega and no Visual Editing markers; SanityLive script reference present.
- [x] `npm run dev` with draft mode **enabled** via `/api/draft-mode/enable`: stega encoded, `<VisualEditing>` rendered, `<DraftModeToast>` rendered, NavbarFallback streamed then swapped, real navbar/footer/header in final HTML.
- [x] `/studio` still loads with no duplicate `<SanityLive>` / `<VisualEditing>`.
- [x] `npm run type-check` (`next typegen && tsc --noEmit`) passes.
- [x] (Production sanity check, not run here) `npm run build` prerenders all `generateStaticParams` entries.