### PR TITLE
Enable experimental Turbopack Rust React Compiler

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,9 @@ const config: NextConfig = {
   cacheComponents: true,
   cacheLife: {default: sanity},
   reactCompiler: true,
+  experimental: {
+    turbopackRustReactCompiler: true,
+  },
   images: {
     remotePatterns: [{hostname: 'cdn.sanity.io'}],
   },

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,9 +5,7 @@ const config: NextConfig = {
   cacheComponents: true,
   cacheLife: {default: sanity},
   reactCompiler: true,
-  experimental: {
-    turbopackRustReactCompiler: true,
-  },
+  experimental: {turbopackRustReactCompiler: true},
   images: {
     remotePatterns: [{hostname: 'cdn.sanity.io'}],
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Enables Next.js 16.3’s experimental native Rust React Compiler path in Turbopack.

## Changes
- Set `experimental.turbopackRustReactCompiler: true` in `next.config.ts`
- Keeps existing `reactCompiler: true` (required for the experimental flag)

Turbopack will run the React Compiler as native code inside the bundler instead of through the Babel transform.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f01b334-1205-472a-baf7-c1227eb1ad74?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f01b334-1205-472a-baf7-c1227eb1ad74&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

