### PR TITLE
Adopt Partial Prefetching

### DIFF
--- a/app/(website)/[slug]/page.tsx
+++ b/app/(website)/[slug]/page.tsx
@@ -48,14 +48,22 @@ export async function generateMetadata(
 export default async function SlugPage({params}: PageProps<'/[slug]'>) {
   const {isEnabled: isDraftMode} = await draftMode()
   if (!isDraftMode) {
-    const {slug} = await params
-    return <CachedSlugPage slug={slug} perspective="published" stega={false} />
+    return (
+      <Suspense>
+        <PublishedSlugPage params={params} />
+      </Suspense>
+    )
   }
   return (
     <Suspense>
       <DynamicSlugPage params={params} />
     </Suspense>
   )
+}
+
+async function PublishedSlugPage({params}: Pick<PageProps<'/[slug]'>, 'params'>) {
+  const {slug} = await params
+  return <CachedSlugPage slug={slug} perspective="published" stega={false} />
 }
 
 async function DynamicSlugPage({params}: Pick<PageProps<'/[slug]'>, 'params'>) {

--- a/app/(website)/projects/[slug]/page.tsx
+++ b/app/(website)/projects/[slug]/page.tsx
@@ -55,14 +55,22 @@ export async function generateMetadata(
 export default async function ProjectSlugPage({params}: PageProps<'/projects/[slug]'>) {
   const {isEnabled: isDraftMode} = await draftMode()
   if (!isDraftMode) {
-    const {slug} = await params
-    return <CachedProjectSlugPage slug={slug} perspective="published" stega={false} />
+    return (
+      <Suspense>
+        <PublishedProjectSlugPage params={params} />
+      </Suspense>
+    )
   }
   return (
     <Suspense>
       <DynamicProjectSlugPage params={params} />
     </Suspense>
   )
+}
+
+async function PublishedProjectSlugPage({params}: Pick<PageProps<'/projects/[slug]'>, 'params'>) {
+  const {slug} = await params
+  return <CachedProjectSlugPage slug={slug} perspective="published" stega={false} />
 }
 
 async function DynamicProjectSlugPage({params}: Pick<PageProps<'/projects/[slug]'>, 'params'>) {

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import {sanity} from 'next-sanity/live/cache-life'
 
 const config: NextConfig = {
   cacheComponents: true,
+  partialPrefetching: true,
   cacheLife: {default: sanity},
   reactCompiler: true,
   images: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adopts [Partial Prefetching](https://nextjs.org/docs/app/guides/adopting-partial-prefetching) so every `<Link>` warms a shared, URL-independent App Shell per route.

- Enables `partialPrefetching: true` in `next.config.ts` (alongside the existing `cacheComponents: true`).
- Restructures the published (non-draft) path of `app/(website)/[slug]/page.tsx` and `app/(website)/projects/[slug]/page.tsx` so `params` is awaited inside a `<Suspense>`-wrapped child (`PublishedSlugPage` / `PublishedProjectSlugPage`), mirroring the existing draft-mode `Dynamic*` components. Previously both pages awaited `params` at the top level, which tied the shared App Shell to a single URL and surfaced the [URL data outside of Suspense](https://nextjs.org/docs/messages/instant-shell-url-data) insight on navigation.

## Why

With the flag on, a `<Link>` prefetches the destination's App Shell — the static and cached content that doesn't depend on the URL — and Next.js builds one shell per route, reused by every link to it. Reading `params` outside `<Suspense>` prevents that reuse and makes navigations non-instant.

## Audit notes

- The codebase has no `<Link prefetch={true}>`, bare `prefetch` props, `router.prefetch()` calls, or custom link wrappers, so there was no legacy full-prefetch behavior to preserve and no per-route incremental adoption was needed (shipped as one change).
- Dev-mode sweep of all routes (`/`, `/[slug]`, `/projects/[slug]`, `/studio/[[...index]]`): the two slug routes surfaced the URL-data insight and are fixed here; the others were clean.
- No routes were left with runtime-prefetch TODO markers: the slug pages' URL-specific content streams in after navigation from behind the layout's shared shell (navbar + footer paint instantly).

## Verification

- `npm run type-check` and `npm run lint` pass.
- `next build` passes; verified navigations against `next build` + `next start` (prefetching is prod-only): the `_rsc` prefetch responses carry the shared App Shell, and clicking through home → project → about paints the navbar/footer shell instantly with the URL-specific body streaming in.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a12e5c3d-40ca-4cb5-a52a-b6df0b9ec7db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a12e5c3d-40ca-4cb5-a52a-b6df0b9ec7db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

