### PR TITLE
Fix build failure when generateStaticParams finds no documents

### DIFF
--- a/app/(website)/[slug]/page.tsx
+++ b/app/(website)/[slug]/page.tsx
@@ -18,7 +18,14 @@ export async function generateStaticParams() {
     query: slugsByTypeQuery,
     params: {type: 'page'} satisfies SlugsByTypeQueryParams,
   })
-  return data
+  if (data.length > 0) {
+    return data
+  }
+  // Cache Components requires `generateStaticParams` to return at least one param — an empty
+  // array fails the build (https://nextjs.org/docs/messages/empty-generate-static-params).
+  // With no page documents in the dataset yet, prerender a placeholder slug that resolves to
+  // the 404 page instead.
+  return [{slug: '__placeholder__'}]
 }
 
 export async function generateMetadata(

--- a/app/(website)/projects/[slug]/page.tsx
+++ b/app/(website)/projects/[slug]/page.tsx
@@ -22,7 +22,14 @@ export async function generateStaticParams() {
     query: slugsByTypeQuery,
     params: {type: 'project'} satisfies SlugsByTypeQueryParams,
   })
-  return data
+  if (data.length > 0) {
+    return data
+  }
+  // Cache Components requires `generateStaticParams` to return at least one param — an empty
+  // array fails the build (https://nextjs.org/docs/messages/empty-generate-static-params).
+  // With no project documents in the dataset yet, prerender a placeholder slug that resolves
+  // to the 404 page instead.
+  return [{slug: '__placeholder__'}]
 }
 
 export async function generateMetadata(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

With Cache Components enabled, `generateStaticParams` must return at least one param — an empty array fails `next build` with [error E898](https://nextjs.org/docs/messages/empty-generate-static-params). When the Sanity dataset has no `page` or `project` documents yet (fresh template setup), both dynamic routes returned empty arrays and the build failed:

```
Error: When using Cache Components, all `generateStaticParams` functions must return at least one result.
    at <unknown> (app/(website)/[slug]/page.tsx:16:8)
> Build error occurred
Error: Failed to collect page data for /[slug]
```

## Fix

When the slugs query returns no documents, `generateStaticParams` in `app/(website)/[slug]/page.tsx` and `app/(website)/projects/[slug]/page.tsx` now falls back to a `__placeholder__` slug, [as recommended by the Next.js docs](https://nextjs.org/docs/app/api-reference/functions/generate-static-params#with-cache-components). The placeholder renders each route's existing `not-found.tsx` (both pages already call `notFound()` when no document matches), so it prerenders as a plain 404 page. As soon as real documents exist, the query returns them and the fallback is never used — builds with data behave exactly as before.

## Verification

Reproduced and verified against a temporary empty dataset (`emptybuildtest9f91`) in the dev Sanity project, without touching existing data:

- Before the fix: `NEXT_PUBLIC_SANITY_DATASET=emptybuildtest9f91 npm run build` fails with E898.
- After the fix: the same build succeeds, prerendering `/__placeholder__` and `/projects/__placeholder__` as static 404 pages; `/` renders the "You don't have a homepage yet" empty state, and navbar/footer/intro-template all degrade gracefully.
- Regression check against the populated `production` dataset: `npm run type-check`, `npm run lint`, `EXPOSE_TESTING_API=1 npm run build` (real slugs prerendered, no placeholder emitted), and `npm run test:e2e` (2/2 passed) all green.

Demo of the production build served from the empty dataset — home page empty state, then `/projects/__placeholder__`, `/projects/some-unknown-slug`, and `/__placeholder__` all rendering their 404 pages:

[empty_dataset_home_and_404_pages_demo.mp4](https://cursor.com/agents/bc-ad3d8852-bad5-466e-82e5-40a2af5e9f91/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fempty_dataset_home_and_404_pages_demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad3d8852-bad5-466e-82e5-40a2af5e9f91?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad3d8852-bad5-466e-82e5-40a2af5e9f91&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

