### PR TITLE
fix(studio): preserve light-dark() in Next Lightning CSS

### DIFF
--- a/e2e/studio-light-dark-css.spec.ts
+++ b/e2e/studio-light-dark-css.spec.ts
@@ -1,0 +1,28 @@
+import {expect, test} from '@playwright/test'
+
+test.describe('studio CSS', () => {
+  test('preserves light-dark() instead of the Lightning CSS polyfill', async ({request}) => {
+    const page = await request.get('/studio')
+    expect(page.ok(), `GET /studio -> ${page.status()}`).toBeTruthy()
+
+    const html = await page.text()
+    const hrefs = [...html.matchAll(/href="(\/_next\/static\/[^"]+\.css)"/g)].map(
+      (match) => match[1],
+    )
+    expect(hrefs.length, 'studio HTML should link production CSS chunks').toBeGreaterThan(0)
+
+    const css = (
+      await Promise.all(
+        hrefs.map(async (href) => {
+          const response = await request.get(href)
+          expect(response.ok(), href).toBeTruthy()
+          return response.text()
+        }),
+      )
+    ).join('\n')
+
+    expect(css).toContain('light-dark(')
+    expect(css).not.toContain('--lightningcss-light')
+    expect(css).not.toContain('--lightningcss-dark')
+  })
+})

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,16 @@ const config: NextConfig = {
     // Opt-in for local/CI production builds measured by `instant()`. Never set
     // EXPOSE_TESTING_API in real production.
     exposeTestingApiInProductionBuild: process.env.EXPOSE_TESTING_API === '1',
+    // Turbopack minifies CSS with Lightning CSS against browserslist defaults
+    // that still down-transpile `light-dark()` into `--lightningcss-light` /
+    // `--lightningcss-dark` toggled only by `prefers-color-scheme`. Studio
+    // theme colors from `@sanity/ui` v5 then follow the OS instead of
+    // `color-scheme` when the two disagree. Exclude the polyfill — same as
+    // Tailwind and sanity#14704 — rather than raising CSS targets (that would
+    // change other lowering). See https://github.com/parcel-bundler/lightningcss/issues/873
+    lightningCssFeatures: {
+      exclude: ['light-dark'],
+    },
   },
   images: {
     remotePatterns: [{hostname: 'cdn.sanity.io'}],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Apply the same Lightning CSS workaround as [sanity#14704](https://github.com/sanity-io/sanity/pull/14704), but through Next.js settings.

Turbopack minifies CSS with Lightning CSS against browserslist defaults that still down-transpile `light-dark()` into `--lightningcss-light` / `--lightningcss-dark` toggled only by `prefers-color-scheme`. After `@sanity/ui` v5 (`ui5`) tokens landed for comments, production Studio contrast breaks when OS appearance ≠ Studio theme.

This repo always builds with `--turbopack`, so the targeted fix is `experimental.lightningCssFeatures.exclude: ['light-dark']` in `next.config.ts`. That is the Next equivalent of Vite's `css.lightningcss.exclude: Features.LightDark`. Raising CSS targets would change other lowering (oklch, prefixes, nesting). `useLightningcss` is left unset so webpack/PostCSS (Tailwind) is not switched off.

See also: [lightningcss#873](https://github.com/parcel-bundler/lightningcss/issues/873).

## Testing

- Lightning CSS against Chrome 111 / Safari 16.4: without the exclude, `ui5` CSS loses all `light-dark()` (118 `--lightningcss-light` tokens). With the exclude, 116 `light-dark()` calls remain.
- Production `next build --turbopack` CSS: 140 `light-dark()` calls across studio chunks, 0 `--lightningcss-*` polyfill tokens.
- Playwright `e2e/studio-light-dark-css.spec.ts` fetches `/studio` CSS chunks and asserts the same. Type-check, lint, and CI are green.
- Manual: Studio appearance Light + DevTools `prefers-color-scheme: dark` — Studio stays light with readable contrast.

[Studio stays light with OS dark emulation](https://cursor.com/agents/bc-39729de4-f5d7-46eb-a53d-5c610085952a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstudio_project_editor_light_theme_os_dark.webp)
[studio_light_theme_with_os_dark.mp4](https://cursor.com/agents/bc-39729de4-f5d7-46eb-a53d-5c610085952a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstudio_light_theme_with_os_dark.mp4)

## Review

- Start at `next.config.ts` (`experimental.lightningCssFeatures`).
- Regression: `e2e/studio-light-dark-css.spec.ts`.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39729de4-f5d7-46eb-a53d-5c610085952a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39729de4-f5d7-46eb-a53d-5c610085952a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

